### PR TITLE
Handle missing ruby runtime

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Run Setup
         run: cd ${{ github.workspace }} && sudo bin/setup
       - name: Run Bazel Tests
-        run: cd ${{ github.workspace }} && bin/test-suite
+        run: cd ${{ github.workspace }} && sudo bin/test-suite

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run Setup
-        run: cd ${{ github.workspace }} && sudo bin/setup
+        run: cd ${{ github.workspace }} && bin/setup
       - name: Run Bazel Tests
-        run: cd ${{ github.workspace }} && sudo bin/test-suite
+        run: cd ${{ github.workspace }} && bin/test-suite

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run Setup
-        run: cd ${{ github.workspace }} && bin/setup
+        run: cd ${{ github.workspace }} && sudo bin/setup
       - name: Run Bazel Tests
         run: cd ${{ github.workspace }} && bin/test-suite

--- a/README.adoc
+++ b/README.adoc
@@ -108,14 +108,14 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
-rules_ruby_register_toolchains(["ruby-3.0"])
+load("@rules_ruby//ruby:deps.bzl", "register_toolchain")
+register_toolchain("ruby-3.0")
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile
 #———————————————————————————————————————————————————————————————————————
 
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",
@@ -547,7 +547,7 @@ List of glob patterns per gem to be excluded from the library. Keys are the name
 
 [source,python]
 ----
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",
@@ -564,7 +564,7 @@ your workspace. The name should match the name of the bundle.
 
 [source,python]
 ----
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 workspace(
     name = "my_wksp",

--- a/README.adoc
+++ b/README.adoc
@@ -115,10 +115,7 @@ rules_ruby_register_toolchains(["ruby-3.0"])
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile
 #———————————————————————————————————————————————————————————————————————
 
-load(
-    "@rules_ruby//ruby:defs.bzl",
-    "ruby_bundle",
-)
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",
@@ -550,7 +547,7 @@ List of glob patterns per gem to be excluded from the library. Keys are the name
 
 [source,python]
 ----
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",
@@ -567,7 +564,7 @@ your workspace. The name should match the name of the bundle.
 
 [source,python]
 ----
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 workspace(
     name = "my_wksp",

--- a/README.adoc
+++ b/README.adoc
@@ -109,7 +109,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 load("@rules_ruby//ruby:deps.bzl", "register_toolchain")
-register_toolchain("ruby-3.0")
+register_toolchains("ruby-3.0")
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,20 +14,23 @@ versions.check("3.4.1")
 
 load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
+# Register the system ruby version with a custom name.
 ruby_runtime(
-    name = "system_ruby",
+    name = "system_ruby_custom",
     version = "system",
 )
 
-register_toolchains("@system_ruby//:toolchain")
+register_toolchains("@system_ruby_custom//:toolchain")
 
+# Register a versioned ruby with a custom name.
 ruby_runtime(
-    name = "ruby-3.0",
+    name = "ruby3",
     version = "ruby-3.0",
 )
 
-register_toolchains("@ruby-3.0//:toolchain")
+register_toolchains("@ruby3//:toolchain")
 
+# Register a versioned ruby with its default name.
 ruby_runtime("jruby-9.2")
 
 register_toolchains("@jruby-9.2//:toolchain")
@@ -113,7 +116,7 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@system_ruby//:bundle.bzl", "ruby_bundle")
+load("@system_ruby_custom//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,13 +12,25 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-register_ruby_toolchain("system_ruby")
+ruby_runtime(
+    name = "system_ruby",
+    version = "system",
+)
 
-register_ruby_toolchain("ruby-3.0")
+register_toolchains("@system_ruby//:toolchain")
 
-register_ruby_toolchain("jruby-9.2")
+ruby_runtime(
+    name = "ruby-3.0",
+    version = "ruby-3.0",
+)
+
+register_toolchains("@ruby-3.0//:toolchain")
+
+ruby_runtime("jruby-9.2")
+
+register_toolchains("@jruby-9.2//:toolchain")
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,13 +12,13 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
 
-rules_ruby_register_toolchains([
-    "system",
-    "ruby-3.0",
-    "jruby-9.2",
-])
+register_ruby_toolchain("system_ruby")
+
+register_ruby_toolchain("ruby-3.0")
+
+register_ruby_toolchain("jruby-9.2")
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",
@@ -101,9 +101,9 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@rules_ruby//ruby:defs.bzl", "system_ruby_bundle")
+load("@system_ruby//:bundle.bzl", "ruby_bundle")
 
-system_ruby_bundle(
+ruby_bundle(
     name = "bundle",
     bundler_version = "2.1.4",
     excludes = {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,7 @@ versions.check("3.4.1")
 load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
 
 rules_ruby_register_toolchains([
+    "system",
     "ruby-3.0",
     "jruby-9.2",
 ])
@@ -100,9 +101,9 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@rules_ruby//ruby:defs.bzl", "system_ruby_bundle")
 
-ruby_bundle(
+system_ruby_bundle(
     name = "bundle",
     bundler_version = "2.1.4",
     excludes = {

--- a/bin/setup
+++ b/bin/setup
@@ -37,7 +37,7 @@ setup.rbenv() {
     local installed_version="$(ruby -e 'puts RUBY_VERSION' | tr -d '\n')"
     if [[ ${installed_version} == ${ruby_version} ]]; then
       info "RUBY already installed, current version: ${bldylw}${ruby_version}"
-      return 0
+      info "Setting up rbenv anyway"
     fi
   fi
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -11,9 +11,9 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+register_ruby_toolchain("ruby-3.0")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -11,9 +11,11 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-register_ruby_toolchain("ruby-3.0")
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -11,9 +11,11 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-register_ruby_toolchain("workspace_ruby", "ruby-3.0")
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -11,15 +11,15 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+register_ruby_toolchain("workspace_ruby", "ruby-3.0")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@workspace_ruby//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -19,7 +19,7 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -13,7 +13,7 @@ rules_ruby_dependencies()
 
 rules_ruby_register_toolchains(["ruby-3.0"])
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,13 +7,13 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+register_ruby_toolchain("ruby-3.0")
 
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,11 +7,15 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-register_ruby_toolchain("ruby-3.0")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
+
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,13 +10,13 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-2.7.1"])
+register_ruby_toolchain("ruby-2.7.1")
 
-load("@local_config_ruby_ruby-2.7.1//:bundle.bzl", "ruby_bundle")
+load("@ruby-2.7.1//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,11 +10,18 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-register_ruby_toolchain("ruby-2.7.1")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
+
+ruby_runtime(
+    name = "ruby-2.7",
+    version = "ruby-2.7.1",
+)
+
+register_toolchains("@ruby-2.7//:toolchain")
 
 load("@ruby-2.7.1//:bundle.bzl", "ruby_bundle")
 

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -16,7 +16,7 @@ rules_ruby_dependencies()
 
 rules_ruby_register_toolchains(["ruby-2.7.1"])
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-2.7.1//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -15,7 +15,6 @@ load(
 load(
     "@rules_ruby//ruby/private/bundle:def.bzl",
     _bundle_install = "bundle_install",
-    _system_ruby_bundle = "system_ruby_bundle",
 )
 load(
     "@rules_ruby//ruby/private:rspec.bzl",
@@ -43,4 +42,3 @@ ruby_bundle_install = _bundle_install
 ruby_rubocop = _rubocop
 ruby_gemspec = _gemspec
 ruby_gem = _gem
-system_ruby_bundle = _system_ruby_bundle

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -30,6 +30,10 @@ load(
     _gem = "gem",
     _gemspec = "gemspec",
 )
+load(
+    "@rules_ruby//ruby/private:sdk.bzl",
+    _register_ruby_runtime = "register_ruby_runtime",
+)
 
 ruby_mock_toolchain = _mock_toolchain
 ruby_toolchain = _toolchain
@@ -42,3 +46,4 @@ ruby_bundle_install = _bundle_install
 ruby_rubocop = _rubocop
 ruby_gemspec = _gemspec
 ruby_gem = _gem
+ruby_runtime = _register_ruby_runtime

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,5 +1,6 @@
 load(
     "@rules_ruby//ruby/private:toolchain.bzl",
+    _mock_toolchain = "mock_ruby_toolchain",
     _toolchain = "ruby_toolchain",
 )
 load(
@@ -31,6 +32,7 @@ load(
     _gemspec = "gemspec",
 )
 
+ruby_mock_toolchain = _mock_toolchain
 ruby_toolchain = _toolchain
 ruby_library = _library
 ruby_binary = _binary

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -14,8 +14,8 @@ load(
 )
 load(
     "@rules_ruby//ruby/private/bundle:def.bzl",
-    _bundle = "bundle_install",
-    _ruby_bundle = "ruby_bundle_install",
+    _bundle_install = "bundle_install",
+    _system_ruby_bundle = "system_ruby_bundle",
 )
 load(
     "@rules_ruby//ruby/private:rspec.bzl",
@@ -39,8 +39,8 @@ ruby_binary = _binary
 ruby_test = _test
 ruby_rspec_test = _rspec_test
 ruby_rspec = _rspec
-ruby_bundle = _ruby_bundle
-ruby_bundle_install = _bundle
+ruby_bundle_install = _bundle_install
 ruby_rubocop = _rubocop
 ruby_gemspec = _gemspec
 ruby_gem = _gem
+system_ruby_bundle = _system_ruby_bundle

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -3,10 +3,5 @@ load(
     "@rules_ruby//ruby/private:dependencies.bzl",
     _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
-load(
-    "@rules_ruby//ruby/private:sdk.bzl",
-    _register_ruby_toolchain = "register_ruby_toolchain",
-)
 
 rules_ruby_dependencies = _rules_ruby_dependencies
-register_ruby_toolchain = _register_ruby_toolchain

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -5,8 +5,8 @@ load(
 )
 load(
     "@rules_ruby//ruby/private:sdk.bzl",
-    _rules_ruby_register_toolchains = "rules_ruby_register_toolchains",
+    _register_ruby_toolchain = "register_ruby_toolchain",
 )
 
 rules_ruby_dependencies = _rules_ruby_dependencies
-rules_ruby_register_toolchains = _rules_ruby_register_toolchains
+register_ruby_toolchain = _register_ruby_toolchain

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -218,11 +218,3 @@ def ruby_bundle_impl(ctx, ruby_interpreter):
 
     # 5. Generate the BUILD file for the bundle
     generate_bundle_build_file(runtime_ctx, result)
-
-def _system_ruby_bundle_impl(ctx):
-    ruby_bundle_impl(ctx, ctx.path(Label("@local_config_ruby_system//:ruby")))
-
-system_ruby_bundle = repository_rule(
-    implementation = _system_ruby_bundle_impl,
-    attrs = BUNDLE_ATTRS,
-)

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -220,7 +220,7 @@ def ruby_bundle_impl(ctx, ruby_interpreter):
     generate_bundle_build_file(runtime_ctx, result)
 
 def _system_ruby_bundle_impl(ctx):
-    ruby_bundle_impl(ctx, ctx.path("@local_config_ruby_system//:ruby"))
+    ruby_bundle_impl(ctx, ctx.path(Label("@local_config_ruby_system//:ruby")))
 
 system_ruby_bundle = repository_rule(
     implementation = _system_ruby_bundle_impl,

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -173,7 +173,7 @@ def generate_bundle_build_file(runtime_ctx, previous_result):
     if result.return_code:
         fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
 
-def _ruby_bundle_impl(ctx):
+def ruby_bundle_impl(ctx, ruby_interpreter):
     ctx.symlink(ctx.attr.gemfile, ctx.attr.gemfile.name)
     if ctx.attr.gemfile_lock:
         ctx.symlink(ctx.attr.gemfile_lock, ctx.attr.gemfile_lock.name)
@@ -192,7 +192,7 @@ def _ruby_bundle_impl(ctx):
     # Setup this provider that we pass around between functions for convenience
     runtime_ctx = RubyRuntimeInfo(
         ctx = ctx,
-        interpreter = ctx.path(ctx.attr.ruby_interpreter),
+        interpreter = ruby_interpreter,
         environment = {"RUBYOPT": "--enable-gems"},
     )
 
@@ -219,7 +219,10 @@ def _ruby_bundle_impl(ctx):
     # 5. Generate the BUILD file for the bundle
     generate_bundle_build_file(runtime_ctx, result)
 
-ruby_bundle_install = repository_rule(
-    implementation = _ruby_bundle_impl,
+def _system_ruby_bundle_impl(ctx):
+    ruby_bundle_impl(ctx, ctx.path("@local_config_ruby_system//:ruby"))
+
+system_ruby_bundle = repository_rule(
+    implementation = _system_ruby_bundle_impl,
     attrs = BUNDLE_ATTRS,
 )

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -70,9 +70,6 @@ RSPEC_ATTRS.update(RUBY_ATTRS)
 RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
-    "ruby_interpreter": attr.label(
-        default = "@local_config_ruby_system//:ruby",
-    ),
     "gemfile": attr.label(
         allow_single_file = True,
         mandatory = True,

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -193,6 +193,6 @@ def get_supported_version(version):
             break
 
     if not supported_version:
-        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
+        fail("ruby_runtime: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
 
     return supported_version

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -193,6 +193,6 @@ def get_supported_version(version):
             break
 
     if not supported_version:
-        fail("rules_ruby_register_toolchains: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
+        fail("register_ruby_toolchain: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
 
     return supported_version

--- a/ruby/private/dependencies.bzl
+++ b/ruby/private/dependencies.bzl
@@ -3,6 +3,7 @@ Dependencies
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
 
 def rules_ruby_dependencies():
     if "bazel_skylib" not in native.existing_rules():
@@ -24,3 +25,17 @@ def rules_ruby_dependencies():
             sha256 = "85e26971904cbb387688bd2a9e87c105f7cd7d986dc1b96bb1391924479c5ef6",
             strip_prefix = "rules_pkg-3e0cd514ad1cdd2d23ab3d427d34436f75060018/pkg",
         )
+
+    # Register placeholders for the system ruby.
+    native.bind(
+        name = "rules_ruby_system_jruby_implementation",
+        actual = "%s//:missing_jruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )
+    native.bind(
+        name = "rules_ruby_system_ruby_implementation",
+        actual = "%s//:missing_ruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )
+    native.bind(
+        name = "rules_ruby_system_no_implementation",
+        actual = "%s//:missing_no_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -44,7 +44,6 @@ def _ruby_interpreter_alias_impl(ctx):
     target = runtime.interpreter
     output = ctx.actions.declare_file("ruby_interpreter")
 
-    #fail(target[DefaultInfo].files_to_run.executable)
     ctx.actions.symlink(
         output = output,
         target_file = target[DefaultInfo].files_to_run.executable,

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -14,7 +14,6 @@ def _register_toolchain(version):
         version = supported_version,
     )
 
-    # System toolchain may not exist, and must be registered in WORKSPACE.
     native.register_toolchains(
         "@%s//:toolchain" % name,
     )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,7 +1,7 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
 load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME", "get_supported_version")
 
-def register_ruby_toolchain(name, version = None):
+def register_ruby_runtime(name, version = None):
     """Initializes a ruby toolchain at a specific version.
 
     A special version "system" or "system_ruby" will use whatever version of
@@ -13,7 +13,7 @@ def register_ruby_toolchain(name, version = None):
     downloaded and built for use by the toolchain.  Toolchain selection occurs
     based on the //ruby/runtime:version flag setting.
 
-    For example, `register_toolchain("ruby", "ruby-2.5")` will download and
+    For example, `register_toolchains("ruby", "ruby-2.5")` will download and
     build the latest supported version of Ruby 2.5.
     By default, the system ruby will be used for all Bazel build and
     tests.  However, passing a flag such as:
@@ -40,10 +40,6 @@ def register_ruby_toolchain(name, version = None):
     ruby_runtime(
         name = name,
         version = supported_version,
-    )
-
-    native.register_toolchains(
-        "@%s//:toolchain" % name,
     )
 
     if supported_version == "system":

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,9 +1,37 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
 load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME", "get_supported_version")
 
-def _register_toolchain(version):
-    """Registers ruby toolchains in the WORKSPACE file."""
-    name = "local_config_ruby_%s" % version
+def register_ruby_toolchain(name, version = None):
+    """Initializes a ruby toolchain at a specific version.
+
+    A special version "system" or "system_ruby" will use whatever version of
+    ruby is installed on the host system.  Besides that, this rules supports all
+    of versions in the SUPPORTED_VERSIONS list.  The most recent matching
+    version will beselected.
+
+    If the current system ruby doesn't match a given version, it will be
+    downloaded and built for use by the toolchain.  Toolchain selection occurs
+    based on the //ruby/runtime:version flag setting.
+
+    For example, `register_toolchain("ruby", "ruby-2.5")` will download and
+    build the latest supported version of Ruby 2.5.
+    By default, the system ruby will be used for all Bazel build and
+    tests.  However, passing a flag such as:
+        --@rules_ruby//ruby/runtime:version="ruby-2.5"
+    will select the Ruby 2.5 installation.
+
+    Optionally, a single string can be passed to this macro and it will use it
+    for both the name and version.
+
+    Args:
+        name: the name of the generated Bazel repository
+        version: a version identifier (e.g. system, ruby-2.5, jruby-9.2)
+    """
+    if not version:
+        version = name
+    if version == "system_ruby":
+        # Special handling to give the system ruby repo a friendly name.
+        version = "system"
 
     supported_version = get_supported_version(version)
     if supported_version.startswith("ruby-"):
@@ -18,60 +46,20 @@ def _register_toolchain(version):
         "@%s//:toolchain" % name,
     )
 
-def rules_ruby_register_toolchains(versions = []):
-    """Initializes ruby toolchains at different supported versions.
-
-    A special version "system" will use whatever version of ruby is installed
-    on the host system.  Besides that, this rules supports all of versions in
-    the SUPPORTED_VERSIONS list.  The most recent matching version will be
-    selected.
-
-    If the current system ruby doesn't match a given version, it will be
-    downloaded and built for use by the toolchain.  Toolchain selection occurs
-    based on the //ruby/runtime:version flag setting.
-
-    For example,
-        rules_ruby_register_toolchains(["system", ruby-2.5", "jruby-9.2"])` will
-    download and build the latest supported version of Ruby 2.5 and jruby 9.2.
-    By default, the system ruby will be used for all Bazel build and
-    tests.  However, passing a flag such as:
-        --@rules_ruby//ruby/runtime:version="ruby-2.5"
-    will select the Ruby 2.5 installation.
-
-    Args:
-      versions: a list of version identifiers
-    """
-    for version in versions:
-        _register_toolchain(version)
-
-    if not "system" in versions:
+    if supported_version == "system":
         native.bind(
             name = "rules_ruby_system_jruby_implementation",
-            actual = "%s//:missing_jruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+            actual = "@%s//:jruby_implementation" % name,
         )
         native.bind(
             name = "rules_ruby_system_ruby_implementation",
-            actual = "%s//:missing_ruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+            actual = "@%s//:ruby_implementation" % name,
         )
         native.bind(
             name = "rules_ruby_system_no_implementation",
-            actual = "%s//:missing_no_implementation" % RULES_RUBY_WORKSPACE_NAME,
-        )
-
-    else:
-        native.bind(
-            name = "rules_ruby_system_jruby_implementation",
-            actual = "@local_config_ruby_system//:jruby_implementation",
-        )
-        native.bind(
-            name = "rules_ruby_system_ruby_implementation",
-            actual = "@local_config_ruby_system//:ruby_implementation",
-        )
-        native.bind(
-            name = "rules_ruby_system_no_implementation",
-            actual = "@local_config_ruby_system//:no_implementation",
+            actual = "@%s//:no_implementation" % name,
         )
         native.bind(
             name = "rules_ruby_system_interpreter",
-            actual = "@local_config_ruby_system//:ruby",
+            actual = "@%s//:ruby" % name,
         )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -14,11 +14,10 @@ def _register_toolchain(version):
         version = supported_version,
     )
 
-    if version != "system":
-        # System toolchain may not exist, and must be registered in WORKSPACE.
-        native.register_toolchains(
-            "@%s//:toolchain" % name,
-        )
+    # System toolchain may not exist, and must be registered in WORKSPACE.
+    native.register_toolchains(
+        "@%s//:toolchain" % name,
+    )
 
 def rules_ruby_register_toolchains(versions = []):
     """Initializes ruby toolchains at different supported versions.
@@ -39,11 +38,6 @@ def rules_ruby_register_toolchains(versions = []):
     tests.  However, passing a flag such as:
         --@rules_ruby//ruby/runtime:version="ruby-2.5"
     will select the Ruby 2.5 installation.
-
-    Note: since the system toolchain may not exist, the following needs to be
-    called from WORKSPACE:
-        load("@local_config_ruby_system//:register.bzl", "register_system_ruby")
-        register_system_ruby()
 
     Args:
       versions: a list of version identifiers

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,5 +1,5 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
-load(":constants.bzl", "get_supported_version", "RULES_RUBY_WORKSPACE_NAME")
+load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME", "get_supported_version")
 
 def _register_toolchain(version):
     """Registers ruby toolchains in the WORKSPACE file."""

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,5 +1,5 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
-load(":constants.bzl", "get_supported_version")
+load(":constants.bzl", "get_supported_version", "RULES_RUBY_WORKSPACE_NAME")
 
 def _register_toolchain(version):
     """Registers ruby toolchains in the WORKSPACE file."""
@@ -44,19 +44,34 @@ def rules_ruby_register_toolchains(versions = []):
     for version in versions:
         _register_toolchain(version)
 
-    native.bind(
-        name = "rules_ruby_system_jruby_implementation",
-        actual = "@local_config_ruby_system//:jruby_implementation",
-    )
-    native.bind(
-        name = "rules_ruby_system_ruby_implementation",
-        actual = "@local_config_ruby_system//:ruby_implementation",
-    )
-    native.bind(
-        name = "rules_ruby_system_no_implementation",
-        actual = "@local_config_ruby_system//:no_implementation",
-    )
-    native.bind(
-        name = "rules_ruby_system_interpreter",
-        actual = "@local_config_ruby_system//:ruby",
-    )
+    if not "system" in versions:
+        native.bind(
+            name = "rules_ruby_system_jruby_implementation",
+            actual = "%s//:missing_jruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+        )
+        native.bind(
+            name = "rules_ruby_system_ruby_implementation",
+            actual = "%s//:missing_ruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+        )
+        native.bind(
+            name = "rules_ruby_system_no_implementation",
+            actual = "%s//:missing_no_implementation" % RULES_RUBY_WORKSPACE_NAME,
+        )
+
+    else:
+        native.bind(
+            name = "rules_ruby_system_jruby_implementation",
+            actual = "@local_config_ruby_system//:jruby_implementation",
+        )
+        native.bind(
+            name = "rules_ruby_system_ruby_implementation",
+            actual = "@local_config_ruby_system//:ruby_implementation",
+        )
+        native.bind(
+            name = "rules_ruby_system_no_implementation",
+            actual = "@local_config_ruby_system//:no_implementation",
+        )
+        native.bind(
+            name = "rules_ruby_system_interpreter",
+            actual = "@local_config_ruby_system//:ruby",
+        )

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -44,9 +44,6 @@ def rules_ruby_register_toolchains(versions = []):
     for version in versions:
         _register_toolchain(version)
 
-    # Always provide a system toolchain for internal use.
-    if not "system" in version:
-        _register_toolchain("system")
     native.bind(
         name = "rules_ruby_system_jruby_implementation",
         actual = "@local_config_ruby_system//:jruby_implementation",

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -14,9 +14,11 @@ def _register_toolchain(version):
         version = supported_version,
     )
 
-    native.register_toolchains(
-        "@%s//:toolchain" % name,
-    )
+    if version != "system":
+        # System toolchain may not exist, and must be registered in WORKSPACE.
+        native.register_toolchains(
+            "@%s//:toolchain" % name,
+        )
 
 def rules_ruby_register_toolchains(versions = []):
     """Initializes ruby toolchains at different supported versions.
@@ -38,6 +40,11 @@ def rules_ruby_register_toolchains(versions = []):
         --@rules_ruby//ruby/runtime:version="ruby-2.5"
     will select the Ruby 2.5 installation.
 
+    Note: since the system toolchain may not exist, the following needs to be
+    called from WORKSPACE:
+        load("@local_config_ruby_system//:register.bzl", "register_system_ruby")
+        register_system_ruby()
+
     Args:
       versions: a list of version identifiers
     """
@@ -50,6 +57,14 @@ def rules_ruby_register_toolchains(versions = []):
     native.bind(
         name = "rules_ruby_system_jruby_implementation",
         actual = "@local_config_ruby_system//:jruby_implementation",
+    )
+    native.bind(
+        name = "rules_ruby_system_ruby_implementation",
+        actual = "@local_config_ruby_system//:ruby_implementation",
+    )
+    native.bind(
+        name = "rules_ruby_system_no_implementation",
+        actual = "@local_config_ruby_system//:none",
     )
     native.bind(
         name = "rules_ruby_system_interpreter",

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -64,7 +64,7 @@ def rules_ruby_register_toolchains(versions = []):
     )
     native.bind(
         name = "rules_ruby_system_no_implementation",
-        actual = "@local_config_ruby_system//:none",
+        actual = "@local_config_ruby_system//:no_implementation",
     )
     native.bind(
         name = "rules_ruby_system_interpreter",

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -61,3 +61,29 @@ def ruby_toolchain(
         toolchain = ":%s" % impl_name,
         **kwargs
     )
+
+def _mock_ruby_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(),
+    ]
+
+_mock_ruby_toolchain = rule(
+    implementation = _mock_ruby_toolchain_impl,
+)
+
+def mock_ruby_toolchain(
+        name,
+        rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
+        **kwargs):
+    impl_name = name + "_sdk"
+    _mock_ruby_toolchain(
+        name = impl_name,
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "%s//ruby:toolchain_type" % rules_ruby_workspace,
+        toolchain = ":%s" % impl_name,
+        exec_compatible_with = ["@platforms//:incompatible"],
+        target_compatible_with = ["@platforms//:incompatible"],
+        **kwargs
+    )

--- a/ruby/private/toolchains/BUILD
+++ b/ruby/private/toolchains/BUILD
@@ -1,1 +1,0 @@
-package(default_visibility = ["//ruby/private:__pkg__"])

--- a/ruby/private/toolchains/BUILD.bazel
+++ b/ruby/private/toolchains/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//ruby/private:__pkg__"])
+
+# Placeholders for cases when no system ruby is requested
+string_flag(
+    name = "internal_missing_ruby",
+    build_setting_default = "none",
+    values = [
+        "none",
+        "ruby",
+        "jruby",
+    ],
+)
+
+config_setting(
+    name = "missing_jruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "jruby",
+    },
+)
+
+config_setting(
+    name = "missing_ruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "ruby",
+    },
+)
+
+config_setting(
+    name = "missing_no_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "none",
+    },
+)
+
+# vim: set ft=bzl :

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -1,55 +1,11 @@
-load(
-    "{rules_ruby_workspace}//ruby:defs.bzl",
-    "ruby_library",
-    "ruby_toolchain",
-)
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
-ruby_toolchain(
-    name = "toolchain",
-    interpreter = "//:ruby_bin",
-    rules_ruby_workspace = "{rules_ruby_workspace}",
-    runtime = "//:runtime",
-    headers = "//:headers",
-    target_settings = [
-        "{rules_ruby_workspace}//ruby/runtime:{setting}"
-    ],
-    # TODO(yugui) Extract platform info from RbConfig
-    # exec_compatible_with = [],
-    # target_compatible_with = [],
-)
-
-sh_binary(
-    name = "ruby_bin",
-    srcs = ["ruby"],
-    data = [":runtime"],
-)
-
-cc_import(
-    name = "libruby",
-    hdrs = glob({hdrs}),
-    shared_library = {shared_library},
-    static_library = {static_library},
-)
-
-cc_library(
-    name = "headers",
-    hdrs = glob({hdrs}),
-    includes = {includes},
-)
-
-filegroup(
-    name = "runtime",
-    srcs = glob(
-        include = ["**/*"],
-        exclude = [
-            "BUILD.bazel",
-            "WORKSPACE",
-        ],
-    ),
-)
+# Toolchain targets.  These will be mocked out with stubs if no ruby version
+# can be found.
+{toolchain}
 
 # Provide config settings to signal the ruby platform to downstream code.
 # This should never be overridden, and is determined automatically during the
@@ -58,6 +14,7 @@ string_flag(
     name = "internal_ruby_implementation",
     build_setting_default = "{implementation}",
     values = [
+        "none",
         "ruby",
         "jruby",
     ],
@@ -74,6 +31,13 @@ config_setting(
     name = "ruby_implementation",
     flag_values = {
         ":internal_ruby_implementation": "ruby",
+    },
+)
+
+config_setting(
+    name = "no_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "none",
     },
 )
 

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -236,7 +236,7 @@ def system_ruby_is_correct_version(ctx, version):
 def _ruby_runtime_impl(ctx):
     # If the current version of ruby is correct use that
     version = ctx.attr.version
-    if version == "system":  # or system_ruby_is_correct_version(ctx, version):
+    if version == "system" or system_ruby_is_correct_version(ctx, version):
         interpreter_path = ctx.which("ruby")
     else:
         _install_ruby_version(ctx, version)

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -240,7 +240,7 @@ def _ruby_runtime_impl(ctx):
             version = ruby_version,
             setting = "config_system" if version == "system" else "config_%s-%s" % (ruby_impl, ruby_version),
         )
-        register_bzl = _register_bzl
+        register_bzl = _register_bzl.format(ctx.name)
     else:
         print("WARNING: no system ruby available, builds against system ruby will fail")
         support = "none"

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -236,7 +236,7 @@ def system_ruby_is_correct_version(ctx, version):
 def _ruby_runtime_impl(ctx):
     # If the current version of ruby is correct use that
     version = ctx.attr.version
-    if version == "system": # or system_ruby_is_correct_version(ctx, version):
+    if version == "system":  # or system_ruby_is_correct_version(ctx, version):
         interpreter_path = ctx.which("ruby")
     else:
         _install_ruby_version(ctx, version)
@@ -267,7 +267,7 @@ def _ruby_runtime_impl(ctx):
         support = "none"
         ruby_impl = "none"
         toolchain = _mock_toolchain.format(
-            rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME
+            rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
         )
         ctx.file("ruby", content = "", executable = True)
         bundle_bzl = _mock_bundle_bzl

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -39,19 +39,37 @@ _ruby_interpreter_alias(
 # For example: --@rules_ruby//ruby/runtime:version=jruby-9.3
 string_flag(
     name = "version",
-    build_setting_default = "system",
-    values = ["system"] + SUPPORTED_MAJOR_MINOR_VERSIONS,
+    build_setting_default = "auto",
+    values = ["auto", "system"] + SUPPORTED_MAJOR_MINOR_VERSIONS,
 )
 
 config_setting(
-    name = "config_system",
+    name = "config_auto",
+    flag_values = {"version": "auto"},
+)
+
+config_setting(
+    name = "internal_config_system",
     flag_values = {"version": "system"},
 )
 
 [
     config_setting(
-        name = "config_" + get_supported_version(version),
+        name = "internal_config_" + get_supported_version(version),
         flag_values = {"version": version},
+    )
+    for version in SUPPORTED_MAJOR_MINOR_VERSIONS
+]
+
+selects.config_setting_group(
+    name = "config_system",
+    match_any = [":config_auto", ":internal_config_system"],
+)
+
+[
+    selects.config_setting_group(
+        name = "config_" + get_supported_version(version),
+        match_any = [":config_auto", ":internal_config_" + get_supported_version(version)],
     )
     for version in SUPPORTED_MAJOR_MINOR_VERSIONS
 ]

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -40,7 +40,10 @@ _ruby_interpreter_alias(
 string_flag(
     name = "version",
     build_setting_default = "auto",
-    values = ["auto", "system"] + SUPPORTED_MAJOR_MINOR_VERSIONS,
+    values = [
+        "auto",
+        "system",
+    ] + SUPPORTED_MAJOR_MINOR_VERSIONS,
 )
 
 config_setting(
@@ -63,13 +66,19 @@ config_setting(
 
 selects.config_setting_group(
     name = "config_system",
-    match_any = [":config_auto", ":internal_config_system"],
+    match_any = [
+        ":config_auto",
+        ":internal_config_system",
+    ],
 )
 
 [
     selects.config_setting_group(
         name = "config_" + get_supported_version(version),
-        match_any = [":config_auto", ":internal_config_" + get_supported_version(version)],
+        match_any = [
+            ":config_auto",
+            ":internal_config_" + get_supported_version(version),
+        ],
     )
     for version in SUPPORTED_MAJOR_MINOR_VERSIONS
 ]

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -68,7 +68,7 @@ selects.config_setting_group(
     name = "config_system_ruby",
     match_all = [
         ":config_system",
-        "//external:rules_ruby_system_jruby_implementation",
+        "//external:rules_ruby_system_ruby_implementation",
     ],
 )
 
@@ -88,6 +88,14 @@ selects.config_setting_group(
 
 selects.config_setting_group(
     name = "config_jruby",
-    match_any = [":config_system_ruby"] +
+    match_any = [":config_system_jruby"] +
                 [":config_%s" % v for v in ALL_JRUBY_MAJOR_MINOR_VERSIONS],
+)
+
+selects.config_setting_group(
+    name = "config_system_none",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_no_implementation",
+    ],
 )

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-register_ruby_toolchain("system_ruby")
+ruby_runtime("system_ruby")
+
+register_toolchains("@system_ruby//:toolchain")

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain")
 
-rules_ruby_register_toolchains()
+register_ruby_toolchain("system_ruby")

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -11,7 +11,7 @@ rules_ruby_dependencies()
 
 rules_ruby_register_toolchains(["ruby-3.0"])
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,13 +5,13 @@ local_repository(
     path = "../../../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+register_ruby_toolchain("ruby-3.0")
 
-load("@local_config_ruby_ruby-3.0//:bundle.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,11 +5,15 @@ local_repository(
     path = "../../../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "register_ruby_toolchain", "rules_ruby_dependencies")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-register_ruby_toolchain("ruby-3.0")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
+
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 


### PR DESCRIPTION
When no system ruby can be found, we don't want to break the entire repo.  This change makes it so that all our repository rules continue to work, and the failure only occurs when someone attempts to use the ruby toolchain (which never gets created in this case).

Closes #9 