### PR TITLE
Disable "auto" version selection option

### DIFF
--- a/bin/deps
+++ b/bin/deps
@@ -9,18 +9,13 @@
 # setup will re-install it.
 # —————————————————————————————————————————————————————————————————————————————————————
 
-set -ex
 
+export BASHMATIC_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 [[ -z ${BASHMATIC_HOME} ]] && export BASHMATIC_HOME="${HOME}/.bashmatic"
-[[ -d ${BASHMATIC_HOME} ]] || {
-  curl -fsSL https://github.com/kigster/bashmatic/archive/refs/tags/v3.0.7.tar.gz | tar zx
-  pushd bashmatic-3.0.7
-  bin/bashmatic-install -q
-  popd
-}
+[[ -d ${BASHMATIC_HOME} ]] || bash -c "$(curl -fsSL https://bashmatic.re1.re); bashmatic-install -v -f -b v2.7.2"
 
 # shellcheck disable=SC1090
-source "${BASHMATIC_HOME}/init.sh"
+source "${BASHMATIC_HOME}/init.sh" 1>/dev/null 2>&1
 command -v rbenv >/dev/null && eval "$(rbenv init -)"
 
 __version.detect() {

--- a/bin/deps
+++ b/bin/deps
@@ -9,12 +9,18 @@
 # setup will re-install it.
 # —————————————————————————————————————————————————————————————————————————————————————
 
+set -ex
 
 [[ -z ${BASHMATIC_HOME} ]] && export BASHMATIC_HOME="${HOME}/.bashmatic"
-[[ -d ${BASHMATIC_HOME} ]] || bash -c "$(curl -fsSL https://bashmatic.re1.re); bashmatic-install -q"
+[[ -d ${BASHMATIC_HOME} ]] || {
+  curl -fsSL https://github.com/kigster/bashmatic/archive/refs/tags/v3.0.7.tar.gz | tar zx
+  pushd bashmatic-3.0.7
+  bin/bashmatic-install -q
+  popd
+}
 
 # shellcheck disable=SC1090
-source "${BASHMATIC_HOME}/init.sh" 1>/dev/null 2>&1
+source "${BASHMATIC_HOME}/init.sh"
 command -v rbenv >/dev/null && eval "$(rbenv init -)"
 
 __version.detect() {

--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,9 @@
 # setup will re-install it.
 # —————————————————————————————————————————————————————————————————————————————————————
 
+set -ex
+
+export BASHMATIC_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 source "bin/deps"
 
 #—————————————————————————————————————————————————————————————————————————————————————————————————————————————
@@ -115,9 +118,11 @@ setup.git-hook() {
 }
 
 setup.os-specific() {
-  local os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  local os="${BASHMATIC_OS}"
   local setup_script
   setup_script="./bin/setup-${os}"
+  echo "UNAME: $(which uname) $(uname) $(uname -s) $(uname -m)"
+  echo "OS: ${os} ${setup_script}"
 
   if [[ -x "${setup_script}" ]]; then
     set -e
@@ -132,6 +137,8 @@ setup.os-specific() {
       /usr/bin/env bash bin/show-env || true
     fi
   else
+    echo "Not executable:"
+    ls -l "${setup_script}"
     error "Operating system ${os} is not currently supported." >&2
     return 1
   fi

--- a/bin/setup
+++ b/bin/setup
@@ -14,9 +14,6 @@
 # setup will re-install it.
 # —————————————————————————————————————————————————————————————————————————————————————
 
-set -ex
-
-export BASHMATIC_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 source "bin/deps"
 
 #—————————————————————————————————————————————————————————————————————————————————————————————————————————————
@@ -118,11 +115,9 @@ setup.git-hook() {
 }
 
 setup.os-specific() {
-  local os="${BASHMATIC_OS}"
+  local os="$(uname -s | tr '[:upper:]' '[:lower:]')"
   local setup_script
   setup_script="./bin/setup-${os}"
-  echo "UNAME: $(which uname) $(uname) $(uname -s) $(uname -m)"
-  echo "OS: ${os} ${setup_script}"
 
   if [[ -x "${setup_script}" ]]; then
     set -e
@@ -137,8 +132,6 @@ setup.os-specific() {
       /usr/bin/env bash bin/show-env || true
     fi
   else
-    echo "Not executable:"
-    ls -l "${setup_script}"
     error "Operating system ${os} is not currently supported." >&2
     return 1
   fi

--- a/bin/test-suite
+++ b/bin/test-suite
@@ -155,13 +155,15 @@ test.buildifier() {
 
 # Builds and runs workspace inside examples/simple_script
 test.simple-script() {
+  # This workspace requires a version specification
+  local RUBY_VERSION="--@rules_ruby//ruby/runtime:version=ruby-3.0 "
   __test.exec simple-script "
     cd examples/simple_script
     bazel ${BAZEL_OPTS} info;                                                  echo; echo
-    bazel ${BAZEL_OPTS} build ${BAZEL_BASE_BUILD_OPTS} -- //... ;                   echo; echo
-    bazel ${BAZEL_OPTS} test ${BAZEL_BASE_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //... ; echo; echo
-    echo run :bin;        bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :bin
-    echo run :rubocop;    bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :rubocop
+    bazel ${BAZEL_OPTS} build ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BASE_BUILD_OPTS} ${BAZEL_TEST_OPTS}  ${RUBY_VERSION} -- //... ; echo; echo
+    echo run :bin;        bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} :bin
+    echo run :rubocop;    bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} :rubocop
   "
 }
 

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -76,7 +76,6 @@ selects.config_setting_group(
     selects.config_setting_group(
         name = "config_" + get_supported_version(version),
         match_any = [
-            ":config_auto",
             ":internal_config_" + get_supported_version(version),
         ],
     )


### PR DESCRIPTION
The attempt to get "auto" behavior for version selection is completely broken.  It results in multiple active toolchains, where the wrong one can end up selected (even if that ruby version doesn't exist!).  For now, "auto" will be synonymous with "system".

Once https://github.com/protocolbuffers/rules_ruby/issues/2 is complete, we can revisit this behavior.  If the client WORKSPACE files specifies *all* allowed versions of ruby, we can organically select a hermetic default and allow overriding with system or a pinned version