### PR TITLE
Export JRuby jar files

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test-suite:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-suite:
+    name: "Test Suite"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false   # Don't cancel all jobs if one fails.
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Setup
+        run: cd ${{ github.workspace }} && bin/setup
+      - name: Run Bazel Tests
+        run: cd ${{ github.workspace }} && bin/test-suite

--- a/README.adoc
+++ b/README.adoc
@@ -108,17 +108,14 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
-rules_ruby_register_toolchains(["ruby-3.0"])
+load("@rules_ruby//ruby:deps.bzl", "register_toolchain")
+register_toolchains("ruby-3.0")
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile
 #———————————————————————————————————————————————————————————————————————
 
-load(
-    "@rules_ruby//ruby:defs.bzl",
-    "ruby_bundle",
-)
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",
@@ -550,7 +547,7 @@ List of glob patterns per gem to be excluded from the library. Keys are the name
 
 [source,python]
 ----
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",
@@ -567,7 +564,7 @@ your workspace. The name should match the name of the bundle.
 
 [source,python]
 ----
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 workspace(
     name = "my_wksp",

--- a/README.adoc
+++ b/README.adoc
@@ -97,12 +97,7 @@ git_repository(
     branch = "master"
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
-
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 rules_ruby_dependencies()
 
 #———————————————————————————————————————————————————————————————————————
@@ -113,7 +108,8 @@ rules_ruby_dependencies()
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+rules_ruby_register_toolchains(["ruby-3.0"])
 
 #———————————————————————————————————————————————————————————————————————
 # Now, load the ruby_bundle rule & install gems specified in the Gemfile
@@ -486,8 +482,7 @@ ruby_bundle(
     excludes = {},
     srcs = [],
     vendor_cache = False,
-    ruby_sdk = "@org_ruby_lang_ruby_toolchain",
-    ruby_interpreter = "@org_ruby_lang_ruby_toolchain//:ruby",
+    ruby_interpreter = "@rules_ruby//ruby/runtime:interpreter",
 )
 ----
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "rules_ruby")
 
-load("@//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_select_sdk")
+load("@//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
@@ -12,7 +12,12 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-rules_ruby_select_sdk("3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+
+rules_ruby_register_toolchains([
+    "ruby-3.0",
+    "jruby-9.2",
+])
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,12 +12,28 @@ load("@bazel_skylib//lib:versions.bzl", "versions")
 
 versions.check("3.4.1")
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-rules_ruby_register_toolchains([
-    "ruby-3.0",
-    "jruby-9.2",
-])
+# Register the system ruby version with a custom name.
+ruby_runtime(
+    name = "system_ruby_custom",
+    version = "system",
+)
+
+register_toolchains("@system_ruby_custom//:toolchain")
+
+# Register a versioned ruby with a custom name.
+ruby_runtime(
+    name = "ruby3",
+    version = "ruby-3.0",
+)
+
+register_toolchains("@ruby3//:toolchain")
+
+# Register a versioned ruby with its default name.
+ruby_runtime("jruby-9.2")
+
+register_toolchains("@jruby-9.2//:toolchain")
 
 local_repository(
     name = "rules_ruby_ruby_tests_testdata_another_workspace",
@@ -100,7 +116,7 @@ container_pull(
     repository = "library/ruby",
 )
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@system_ruby_custom//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/bin/deps
+++ b/bin/deps
@@ -10,8 +10,9 @@
 # —————————————————————————————————————————————————————————————————————————————————————
 
 
+export BASHMATIC_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 [[ -z ${BASHMATIC_HOME} ]] && export BASHMATIC_HOME="${HOME}/.bashmatic"
-[[ -d ${BASHMATIC_HOME} ]] || bash -c "$(curl -fsSL https://bashmatic.re1.re); bashmatic-install -q"
+[[ -d ${BASHMATIC_HOME} ]] || bash -c "$(curl -fsSL https://bashmatic.re1.re); bashmatic-install -v -f -b v2.7.2"
 
 # shellcheck disable=SC1090
 source "${BASHMATIC_HOME}/init.sh" 1>/dev/null 2>&1

--- a/bin/setup
+++ b/bin/setup
@@ -37,7 +37,7 @@ setup.rbenv() {
     local installed_version="$(ruby -e 'puts RUBY_VERSION' | tr -d '\n')"
     if [[ ${installed_version} == ${ruby_version} ]]; then
       info "RUBY already installed, current version: ${bldylw}${ruby_version}"
-      return 0
+      info "Setting up rbenv anyway"
     fi
   fi
 

--- a/bin/test-suite
+++ b/bin/test-suite
@@ -32,11 +32,6 @@ export BashMatic__Expr="
   [[ -f ${HOME}/.bashmatic/init.sh ]] && source ${HOME}/.bashmatic/init.sh;
   set -e
 "
-export Bazel__BuildSteps="
-    bazel ${BAZEL_OPTS} info;                                                  echo; echo
-    bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} -- //... ;                   echo; echo
-    bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //... ; echo; echo
-"
 deps.start-clock
 
 run.set-all abort-on-error show-output-on
@@ -162,9 +157,11 @@ test.buildifier() {
 test.simple-script() {
   __test.exec simple-script "
     cd examples/simple_script
-    ${Bazel__BuildSteps}  
-    echo run :bin;        bazel ${BAZEL_OPTS} run   ${BAZEL_BUILD_OPTS} :bin
-    echo run :rubocop;    bazel ${BAZEL_OPTS} run   ${BAZEL_BUILD_OPTS} :rubocop
+    bazel ${BAZEL_OPTS} info;                                                  echo; echo
+    bazel ${BAZEL_OPTS} build ${BAZEL_BASE_BUILD_OPTS} -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BASE_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //... ; echo; echo
+    echo run :bin;        bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :bin
+    echo run :rubocop;    bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :rubocop
   "
 }
 
@@ -172,12 +169,21 @@ test.simple-script() {
 test.example-gem() {
   __test.exec example-gem "
     cd examples/example_gem
-    echo bazel ${BAZEL_OPTS} build ...:all; bazel ${BAZEL_OPTS} build ...:all
+    echo bazel ${BAZEL_OPTS} build ...:all
+    bazel ${BAZEL_OPTS} build --@rules_ruby//ruby/runtime:version=ruby-3.0 ...:all
   "
 }
 
 test.workspace() {
-  __test.exec workspace "${Bazel__BuildSteps}"
+  __test.exec workspace "
+    bazel ${BAZEL_OPTS} info;                                                  echo; echo
+    bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //... ; echo; echo
+    bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} --@rules_ruby//ruby/runtime:version=ruby-3.0 -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} --@rules_ruby//ruby/runtime:version=ruby-3.0 ${BAZEL_TEST_OPTS} -- //... ; echo; echo
+    bazel ${BAZEL_OPTS} build ${BAZEL_BUILD_OPTS} --@rules_ruby//ruby/runtime:version=jruby-9.2 -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BUILD_OPTS} --@rules_ruby//ruby/runtime:version=jruby-9.2 ${BAZEL_TEST_OPTS} -- //... ; echo; echo
+  "
 }
 
 # Private

--- a/bin/test-suite
+++ b/bin/test-suite
@@ -155,13 +155,15 @@ test.buildifier() {
 
 # Builds and runs workspace inside examples/simple_script
 test.simple-script() {
+  # This workspace requires a version specification
+  local RUBY_VERSION="--@rules_ruby//ruby/runtime:version=ruby-3.0 "
   __test.exec simple-script "
     cd examples/simple_script
     bazel ${BAZEL_OPTS} info;                                                  echo; echo
-    bazel ${BAZEL_OPTS} build ${BAZEL_BASE_BUILD_OPTS} -- //... ;                   echo; echo
-    bazel ${BAZEL_OPTS} test ${BAZEL_BASE_BUILD_OPTS} ${BAZEL_TEST_OPTS} -- //... ; echo; echo
-    echo run :bin;        bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :bin
-    echo run :rubocop;    bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} :rubocop
+    bazel ${BAZEL_OPTS} build ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} -- //... ;                   echo; echo
+    bazel ${BAZEL_OPTS} test ${BAZEL_BASE_BUILD_OPTS} ${BAZEL_TEST_OPTS}  ${RUBY_VERSION} -- //... ; echo; echo
+    echo run :bin;        bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} :bin
+    echo run :rubocop;    bazel ${BAZEL_OPTS} run ${BAZEL_BASE_BUILD_OPTS} ${RUBY_VERSION} :rubocop
   "
 }
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -7,15 +7,13 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk("3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+
+rules_ruby_register_toolchains(["ruby-3.0"])
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/example_gem/WORKSPACE
+++ b/examples/example_gem/WORKSPACE
@@ -11,9 +11,11 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -7,15 +7,13 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+
+rules_ruby_register_toolchains(["ruby-3.0"])
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/examples/simple_rails_api/WORKSPACE
+++ b/examples/simple_rails_api/WORKSPACE
@@ -11,15 +11,17 @@ load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+load("@workspace_ruby//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,13 +7,17 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
+
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/examples/simple_script/WORKSPACE
+++ b/examples/simple_script/WORKSPACE
@@ -7,15 +7,11 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+rules_ruby_register_toolchains(["ruby-3.0"])
 
 load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,15 +10,11 @@ local_repository(
     path = "../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "2.7.1")
+rules_ruby_register_toolchains(["ruby-2.7.1"])
 
 load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 

--- a/examples/simple_script_vendored/WORKSPACE
+++ b/examples/simple_script_vendored/WORKSPACE
@@ -10,13 +10,20 @@ local_repository(
     path = "../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-2.7.1"])
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+ruby_runtime(
+    name = "ruby-2.7",
+    version = "ruby-2.7.1",
+)
+
+register_toolchains("@ruby-2.7//:toolchain")
+
+load("@ruby-2.7.1//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "bundle",

--- a/ruby/defs.bzl
+++ b/ruby/defs.bzl
@@ -1,5 +1,6 @@
 load(
     "@rules_ruby//ruby/private:toolchain.bzl",
+    _mock_toolchain = "mock_ruby_toolchain",
     _toolchain = "ruby_toolchain",
 )
 load(
@@ -13,8 +14,7 @@ load(
 )
 load(
     "@rules_ruby//ruby/private/bundle:def.bzl",
-    _bundle = "bundle_install",
-    _ruby_bundle = "ruby_bundle_install",
+    _bundle_install = "bundle_install",
 )
 load(
     "@rules_ruby//ruby/private:rspec.bzl",
@@ -30,15 +30,20 @@ load(
     _gem = "gem",
     _gemspec = "gemspec",
 )
+load(
+    "@rules_ruby//ruby/private:sdk.bzl",
+    _register_ruby_runtime = "register_ruby_runtime",
+)
 
+ruby_mock_toolchain = _mock_toolchain
 ruby_toolchain = _toolchain
 ruby_library = _library
 ruby_binary = _binary
 ruby_test = _test
 ruby_rspec_test = _rspec_test
 ruby_rspec = _rspec
-ruby_bundle = _ruby_bundle
-ruby_bundle_install = _bundle
+ruby_bundle_install = _bundle_install
 ruby_rubocop = _rubocop
 ruby_gemspec = _gemspec
 ruby_gem = _gem
+ruby_runtime = _register_ruby_runtime

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -5,8 +5,8 @@ load(
 )
 load(
     "@rules_ruby//ruby/private:sdk.bzl",
-    _rules_ruby_select_sdk = "rules_ruby_select_sdk",
+    _rules_ruby_register_toolchains = "rules_ruby_register_toolchains",
 )
 
 rules_ruby_dependencies = _rules_ruby_dependencies
-rules_ruby_select_sdk = _rules_ruby_select_sdk
+rules_ruby_register_toolchains = _rules_ruby_register_toolchains

--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -3,10 +3,5 @@ load(
     "@rules_ruby//ruby/private:dependencies.bzl",
     _rules_ruby_dependencies = "rules_ruby_dependencies",
 )
-load(
-    "@rules_ruby//ruby/private:sdk.bzl",
-    _rules_ruby_register_toolchains = "rules_ruby_register_toolchains",
-)
 
 rules_ruby_dependencies = _rules_ruby_dependencies
-rules_ruby_register_toolchains = _rules_ruby_register_toolchains

--- a/ruby/private/BUILD.bazel
+++ b/ruby/private/BUILD.bazel
@@ -1,6 +1,7 @@
 exports_files(
     [
         "binary_wrapper.tpl",
+        "binary_runner.tpl",
     ],
     visibility = ["//visibility:public"],
 )

--- a/ruby/private/binary_runner.tpl
+++ b/ruby/private/binary_runner.tpl
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -n "${RUNFILES_DIR+x}" ]; then
+  PATH_PREFIX=$RUNFILES_DIR/{workspace_name}/
+elif [ -s `dirname $0`/../../MANIFEST ]; then
+  PATH_PREFIX=`cd $(dirname $0); pwd`/
+elif [ -d $0.runfiles ]; then
+  PATH_PREFIX=`cd $0.runfiles; pwd`/{workspace_name}/
+else
+  echo "WARNING: it does not look to be at the .runfiles directory" >&2
+  exit 1
+fi
+
+$PATH_PREFIX{interpreter} -I${PATH_PREFIX} ${PATH_PREFIX}{main} "$@"

--- a/ruby/private/binary_wrapper.tpl
+++ b/ruby/private/binary_wrapper.tpl
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 # Ruby-port of the Bazel's wrapper script for Python
 
 # Copyright 2017 The Bazel Authors. All rights reserved.

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -173,7 +173,7 @@ def generate_bundle_build_file(runtime_ctx, previous_result):
     if result.return_code:
         fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
 
-def _ruby_bundle_impl(ctx):
+def ruby_bundle_impl(ctx, ruby_interpreter):
     ctx.symlink(ctx.attr.gemfile, ctx.attr.gemfile.name)
     if ctx.attr.gemfile_lock:
         ctx.symlink(ctx.attr.gemfile_lock, ctx.attr.gemfile_lock.name)
@@ -192,7 +192,7 @@ def _ruby_bundle_impl(ctx):
     # Setup this provider that we pass around between functions for convenience
     runtime_ctx = RubyRuntimeInfo(
         ctx = ctx,
-        interpreter = ctx.path(ctx.attr.ruby_interpreter),
+        interpreter = ruby_interpreter,
         environment = {"RUBYOPT": "--enable-gems"},
     )
 
@@ -218,8 +218,3 @@ def _ruby_bundle_impl(ctx):
 
     # 5. Generate the BUILD file for the bundle
     generate_bundle_build_file(runtime_ctx, result)
-
-ruby_bundle_install = repository_rule(
-    implementation = _ruby_bundle_impl,
-    attrs = BUNDLE_ATTRS,
-)

--- a/ruby/private/bundle/def.bzl
+++ b/ruby/private/bundle/def.bzl
@@ -116,7 +116,8 @@ def install_bundler(runtime_ctx, bundler_version):
 def bundle_install(runtime_ctx, previous_result):
     cwd = runtime_ctx.ctx.path(".")
     bundler_args = [
-        "install", "-V",
+        "install",
+        "-V",
         "--standalone",
         "--gemfile={}".format(runtime_ctx.ctx.attr.gemfile.name),
         "--jobs=10",  # run a few jobs to ensure no gem install is blocking another
@@ -136,7 +137,10 @@ def bundle_install(runtime_ctx, previous_result):
 
     # Creates a directory and place any executables from the gem there.
     result = run_bundler(runtime_ctx, [
-            "binstubs", "--all", "--path", "{}".format(BUNDLE_BIN_PATH)
+        "binstubs",
+        "--all",
+        "--path",
+        "{}".format(BUNDLE_BIN_PATH),
     ], previous_result)
     if result.return_code:
         fail("bundle binstubs failed: %s%s" % (result.stdout, result.stderr))
@@ -203,7 +207,7 @@ def _ruby_bundle_impl(ctx):
 
     # 2. Generate a Gemfile.lock file if one isn't provided
     if not runtime_ctx.ctx.attr.gemfile_lock:
-        result = set_bundler_config(runtime_ctx, result, has_lock=False)
+        result = set_bundler_config(runtime_ctx, result, has_lock = False)
         result = bundle_install(runtime_ctx, result)
 
     # 3. Set Bundler config in the .bundle/config file

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -70,9 +70,6 @@ RSPEC_ATTRS.update(RUBY_ATTRS)
 RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
-    "ruby_interpreter": attr.label(
-        default = "@local_config_ruby_system//:ruby",
-    ),
     "gemfile": attr.label(
         allow_single_file = True,
         mandatory = True,
@@ -196,6 +193,6 @@ def get_supported_version(version):
             break
 
     if not supported_version:
-        fail("rules_ruby_register_toolchains: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
+        fail("ruby_runtime: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
 
     return supported_version

--- a/ruby/private/constants.bzl
+++ b/ruby/private/constants.bzl
@@ -38,6 +38,10 @@ RUBY_ATTRS = {
         allow_single_file = True,
         default = "binary_wrapper.tpl",
     ),
+    "_runner_template": attr.label(
+        allow_single_file = True,
+        default = "binary_runner.tpl",
+    ),
     "_misc_deps": attr.label_list(
         allow_files = True,
         default = ["@bazel_tools//tools/bash/runfiles"],
@@ -66,11 +70,8 @@ RSPEC_ATTRS.update(RUBY_ATTRS)
 RSPEC_ATTRS.update(_RSPEC_ATTRS)
 
 BUNDLE_ATTRS = {
-    "ruby_sdk": attr.string(
-        default = "@org_ruby_lang_ruby_toolchain",
-    ),
     "ruby_interpreter": attr.label(
-        default = "@org_ruby_lang_ruby_toolchain//:ruby",
+        default = "@local_config_ruby_system//:ruby",
     ),
     "gemfile": attr.label(
         allow_single_file = True,
@@ -154,3 +155,47 @@ GEMSPEC_ATTRS = {
         default = "%s//ruby/private/gemspec:readme_template.tpl" % RULES_RUBY_WORKSPACE_NAME,
     ),
 }
+
+# The full list of supported pinned version numbers.
+SUPPORTED_VERSIONS = [
+    "system",
+    "ruby-2.5.8",
+    "ruby-2.5.9",
+    "ruby-2.6.3",
+    "ruby-2.6.4",
+    "ruby-2.6.5",
+    "ruby-2.6.6",
+    "ruby-2.6.7",
+    "ruby-2.6.8",
+    "ruby-2.6.9",
+    "ruby-2.7.1",
+    "ruby-2.7.2",
+    "ruby-2.7.3",
+    "ruby-2.7.4",
+    "ruby-2.7.5",
+    "ruby-3.0.0",
+    "ruby-3.0.1",
+    "ruby-3.0.2",
+    "ruby-3.0.3",
+    "ruby-3.1.0",
+    "ruby-3.1.1",
+    "jruby-9.2.21.0",  # Corresponded to 2.5.8
+    "jruby-9.3.6.0",  # Corresponds to 2.6.8
+]
+
+def get_supported_version(version):
+    """Transforms a user-friendly version identifier to a full version number."""
+
+    if version[0] >= "0" and version[1] <= "9":
+        version = "ruby-" + version
+
+    supported_version = None
+    for v in sorted(SUPPORTED_VERSIONS, reverse = True):
+        if v.startswith(version):
+            supported_version = v
+            break
+
+    if not supported_version:
+        fail("rules_ruby_register_toolchains: unsupported ruby version '%s' not in '%s'" % (version, SUPPORTED_VERSIONS))
+
+    return supported_version

--- a/ruby/private/dependencies.bzl
+++ b/ruby/private/dependencies.bzl
@@ -3,6 +3,7 @@ Dependencies
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
 
 def rules_ruby_dependencies():
     if "bazel_skylib" not in native.existing_rules():
@@ -24,3 +25,17 @@ def rules_ruby_dependencies():
             sha256 = "85e26971904cbb387688bd2a9e87c105f7cd7d986dc1b96bb1391924479c5ef6",
             strip_prefix = "rules_pkg-3e0cd514ad1cdd2d23ab3d427d34436f75060018/pkg",
         )
+
+    # Register placeholders for the system ruby.
+    native.bind(
+        name = "rules_ruby_system_jruby_implementation",
+        actual = "%s//:missing_jruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )
+    native.bind(
+        name = "rules_ruby_system_ruby_implementation",
+        actual = "%s//:missing_ruby_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )
+    native.bind(
+        name = "rules_ruby_system_no_implementation",
+        actual = "%s//:missing_no_implementation" % RULES_RUBY_WORKSPACE_NAME,
+    )

--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -19,6 +19,17 @@ RubyRuntimeInfo = provider(
     ],
 )
 
+RubyRuntimeToolchainInfo = provider(
+    doc = "Information about a Ruby interpreter, related commands and libraries",
+    fields = {
+        "interpreter": "A label which points the Ruby interpreter",
+        "bundler": "A label which points bundler command",
+        "runtime": "A list of labels which points runtime libraries",
+        "headers": "A list of labels which points to the ruby headers",
+        "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
+    },
+)
+
 RubyGemInfo = provider(
     doc = "Carries info required to package a ruby gem",
     fields = [

--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -25,6 +25,7 @@ RubyRuntimeToolchainInfo = provider(
         "interpreter": "A label which points the Ruby interpreter",
         "bundler": "A label which points bundler command",
         "runtime": "A list of labels which points runtime libraries",
+        "jars": "A list of labels which points to ruby jars",
         "headers": "A list of labels which points to the ruby headers",
         "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
     },

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -44,7 +44,6 @@ def _ruby_interpreter_alias_impl(ctx):
     target = runtime.interpreter
     output = ctx.actions.declare_file("ruby_interpreter")
 
-    #fail(target[DefaultInfo].files_to_run.executable)
     ctx.actions.symlink(
         output = output,
         target_file = target[DefaultInfo].files_to_run.executable,

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -1,0 +1,74 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load(":constants.bzl", "TOOLCHAIN_TYPE_NAME")
+load(":providers.bzl", "RubyRuntimeToolchainInfo")
+
+# These rules expose the runtime targets of whichever toolchain has been resolved.
+
+def _ruby_runtime_alias_impl(ctx):
+    ruby = ctx.toolchains[TOOLCHAIN_TYPE_NAME].ruby_runtime
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(transitive_files = depset(ruby.runtime)),
+            files = depset(ruby.runtime),
+        ),
+        ruby,
+    ]
+
+ruby_runtime_alias = rule(
+    implementation = _ruby_runtime_alias_impl,
+    toolchains = [TOOLCHAIN_TYPE_NAME],
+)
+
+def _ruby_headers_alias_impl(ctx):
+    runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
+    target = runtime.headers
+    return [
+        ctx.attr.runtime[DefaultInfo],
+        target[CcInfo],
+        target[InstrumentedFilesInfo],
+        target[OutputGroupInfo],
+    ]
+
+ruby_headers_alias = rule(
+    implementation = _ruby_headers_alias_impl,
+    attrs = {
+        "runtime": attr.label(
+            doc = "The runtime alias to use.",
+            mandatory = True,
+        ),
+    },
+)
+
+def _ruby_interpreter_alias_impl(ctx):
+    runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
+    target = runtime.interpreter
+    output = ctx.actions.declare_file("ruby_interpreter")
+
+    #fail(target[DefaultInfo].files_to_run.executable)
+    ctx.actions.symlink(
+        output = output,
+        target_file = target[DefaultInfo].files_to_run.executable,
+        is_executable = True,
+    )
+    runfiles = ctx.attr.runtime[DefaultInfo].default_runfiles.merge(
+        ctx.attr.runtime[DefaultInfo].data_runfiles,
+    )
+
+    return [
+        DefaultInfo(
+            files = target.files,
+            runfiles = runfiles,
+            executable = output,
+        ),
+    ]
+
+ruby_interpreter_alias = rule(
+    implementation = _ruby_interpreter_alias_impl,
+    executable = True,
+    attrs = {
+        "runtime": attr.label(
+            doc = "The runtime alias to use.",
+            mandatory = True,
+        ),
+    },
+)

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -19,6 +19,30 @@ ruby_runtime_alias = rule(
     toolchains = [TOOLCHAIN_TYPE_NAME],
 )
 
+def _ruby_jars_alias_impl(ctx):
+    runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
+    target = runtime.jars
+    infos = [
+        DefaultInfo(
+            files = target.files,
+            runfiles = ctx.runfiles(transitive_files = target.files),
+        )
+    ]
+    for jar in infos[0].files.to_list():
+        infos.append(JavaInfo(jar, jar))
+    #fail(infos)
+    return infos
+
+ruby_jars_alias = rule(
+    implementation = _ruby_jars_alias_impl,
+    attrs = {
+        "runtime": attr.label(
+            doc = "The runtime alias to use.",
+            mandatory = True,
+        ),
+    },
+)
+
 def _ruby_headers_alias_impl(ctx):
     runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
     target = runtime.headers

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -26,10 +26,11 @@ def _ruby_jars_alias_impl(ctx):
         DefaultInfo(
             files = target.files,
             runfiles = ctx.runfiles(transitive_files = target.files),
-        )
+        ),
     ]
     for jar in infos[0].files.to_list():
         infos.append(JavaInfo(jar, jar))
+
     #fail(infos)
     return infos
 

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -31,7 +31,6 @@ def _ruby_jars_alias_impl(ctx):
     for jar in infos[0].files.to_list():
         infos.append(JavaInfo(jar, jar))
 
-    #fail(infos)
     return infos
 
 ruby_jars_alias = rule(

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -32,7 +32,7 @@ def rules_ruby_select_sdk(version = "host"):
         "jruby-9.3.6.0",
     ]
 
-    for v in sorted(supported_versions, reverse=True):
+    for v in sorted(supported_versions, reverse = True):
         if v.startswith(version):
             supported_version = v
             break

--- a/ruby/private/sdk.bzl
+++ b/ruby/private/sdk.bzl
@@ -1,9 +1,37 @@
 load("@rules_ruby//ruby/private/toolchains:ruby_runtime.bzl", "ruby_runtime")
-load(":constants.bzl", "get_supported_version")
+load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME", "get_supported_version")
 
-def _register_toolchain(version):
-    """Registers ruby toolchains in the WORKSPACE file."""
-    name = "local_config_ruby_%s" % version
+def register_ruby_runtime(name, version = None):
+    """Initializes a ruby toolchain at a specific version.
+
+    A special version "system" or "system_ruby" will use whatever version of
+    ruby is installed on the host system.  Besides that, this rules supports all
+    of versions in the SUPPORTED_VERSIONS list.  The most recent matching
+    version will beselected.
+
+    If the current system ruby doesn't match a given version, it will be
+    downloaded and built for use by the toolchain.  Toolchain selection occurs
+    based on the //ruby/runtime:version flag setting.
+
+    For example, `register_toolchains("ruby", "ruby-2.5")` will download and
+    build the latest supported version of Ruby 2.5.
+    By default, the system ruby will be used for all Bazel build and
+    tests.  However, passing a flag such as:
+        --@rules_ruby//ruby/runtime:version="ruby-2.5"
+    will select the Ruby 2.5 installation.
+
+    Optionally, a single string can be passed to this macro and it will use it
+    for both the name and version.
+
+    Args:
+        name: the name of the generated Bazel repository
+        version: a version identifier (e.g. system, ruby-2.5, jruby-9.2)
+    """
+    if not version:
+        version = name
+    if version == "system_ruby":
+        # Special handling to give the system ruby repo a friendly name.
+        version = "system"
 
     supported_version = get_supported_version(version)
     if supported_version.startswith("ruby-"):
@@ -14,44 +42,20 @@ def _register_toolchain(version):
         version = supported_version,
     )
 
-    native.register_toolchains(
-        "@%s//:toolchain" % name,
-    )
-
-def rules_ruby_register_toolchains(versions = []):
-    """Initializes ruby toolchains at different supported versions.
-
-    A special version "system" will use whatever version of ruby is installed
-    on the host system.  Besides that, this rules supports all of versions in
-    the SUPPORTED_VERSIONS list.  The most recent matching version will be
-    selected.
-
-    If the current system ruby doesn't match a given version, it will be
-    downloaded and built for use by the toolchain.  Toolchain selection occurs
-    based on the //ruby/runtime:version flag setting.
-
-    For example,
-        rules_ruby_register_toolchains(["system", ruby-2.5", "jruby-9.2"])` will
-    download and build the latest supported version of Ruby 2.5 and jruby 9.2.
-    By default, the system ruby will be used for all Bazel build and
-    tests.  However, passing a flag such as:
-        --@rules_ruby//ruby/runtime:version="ruby-2.5"
-    will select the Ruby 2.5 installation.
-
-    Args:
-      versions: a list of version identifiers
-    """
-    for version in versions:
-        _register_toolchain(version)
-
-    # Always provide a system toolchain for internal use.
-    if not "system" in version:
-        _register_toolchain("system")
-    native.bind(
-        name = "rules_ruby_system_jruby_implementation",
-        actual = "@local_config_ruby_system//:jruby_implementation",
-    )
-    native.bind(
-        name = "rules_ruby_system_interpreter",
-        actual = "@local_config_ruby_system//:ruby",
-    )
+    if supported_version == "system":
+        native.bind(
+            name = "rules_ruby_system_jruby_implementation",
+            actual = "@%s//:jruby_implementation" % name,
+        )
+        native.bind(
+            name = "rules_ruby_system_ruby_implementation",
+            actual = "@%s//:ruby_implementation" % name,
+        )
+        native.bind(
+            name = "rules_ruby_system_no_implementation",
+            actual = "@%s//:no_implementation" % name,
+        )
+        native.bind(
+            name = "rules_ruby_system_interpreter",
+            actual = "@%s//:ruby" % name,
+        )

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -61,3 +61,29 @@ def ruby_toolchain(
         toolchain = ":%s" % impl_name,
         **kwargs
     )
+
+def _mock_ruby_toolchain_impl(ctx):
+    return [
+        platform_common.ToolchainInfo(),
+    ]
+
+_mock_ruby_toolchain = rule(
+    implementation = _mock_ruby_toolchain_impl,
+)
+
+def mock_ruby_toolchain(
+        name,
+        rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
+        **kwargs):
+    impl_name = name + "_sdk"
+    _mock_ruby_toolchain(
+        name = impl_name,
+    )
+    native.toolchain(
+        name = name,
+        toolchain_type = "%s//ruby:toolchain_type" % rules_ruby_workspace,
+        toolchain = ":%s" % impl_name,
+        exec_compatible_with = ["@platforms//:incompatible"],
+        target_compatible_with = ["@platforms//:incompatible"],
+        **kwargs
+    )

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -1,21 +1,13 @@
 load(":constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
-
-RubyRuntimeInfo = provider(
-    doc = "Information about a Ruby interpreter, related commands and libraries",
-    fields = {
-        "interpreter": "A label which points the Ruby interpreter",
-        "bundler": "A label which points bundler command",
-        "runtime": "A list of labels which points runtime libraries",
-        "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
-    },
-)
+load(":providers.bzl", "RubyRuntimeToolchainInfo")
 
 def _ruby_toolchain_impl(ctx):
     return [
         platform_common.ToolchainInfo(
-            ruby_runtime = RubyRuntimeInfo(
+            ruby_runtime = RubyRuntimeToolchainInfo(
                 interpreter = ctx.attr.interpreter,
                 runtime = ctx.files.runtime,
+                headers = ctx.attr.headers,
                 rubyopt = ctx.attr.rubyopt,
             ),
         ),
@@ -35,6 +27,11 @@ _ruby_toolchain = rule(
             allow_files = True,
             cfg = "target",
         ),
+        "headers": attr.label(
+            mandatory = True,
+            allow_files = True,
+            cfg = "target",
+        ),
         "rubyopt": attr.string_list(
             default = [],
         ),
@@ -45,6 +42,7 @@ def ruby_toolchain(
         name,
         interpreter,
         runtime,
+        headers,
         rubyopt = [],
         rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
         **kwargs):
@@ -53,6 +51,7 @@ def ruby_toolchain(
         name = impl_name,
         interpreter = interpreter,
         runtime = runtime,
+        headers = headers,
         rubyopt = rubyopt,
     )
 

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -7,6 +7,7 @@ def _ruby_toolchain_impl(ctx):
             ruby_runtime = RubyRuntimeToolchainInfo(
                 interpreter = ctx.attr.interpreter,
                 runtime = ctx.files.runtime,
+                jars = ctx.attr.jars,
                 headers = ctx.attr.headers,
                 rubyopt = ctx.attr.rubyopt,
             ),
@@ -27,6 +28,11 @@ _ruby_toolchain = rule(
             allow_files = True,
             cfg = "target",
         ),
+        "jars": attr.label(
+            mandatory = True,
+            allow_files = True,
+            cfg = "target",
+        ),
         "headers": attr.label(
             mandatory = True,
             allow_files = True,
@@ -42,6 +48,7 @@ def ruby_toolchain(
         name,
         interpreter,
         runtime,
+        jars,
         headers,
         rubyopt = [],
         rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
@@ -51,6 +58,7 @@ def ruby_toolchain(
         name = impl_name,
         interpreter = interpreter,
         runtime = runtime,
+        jars = jars,
         headers = headers,
         rubyopt = rubyopt,
     )

--- a/ruby/private/toolchains/BUILD
+++ b/ruby/private/toolchains/BUILD
@@ -1,1 +1,0 @@
-package(default_visibility = ["//ruby/private:__pkg__"])

--- a/ruby/private/toolchains/BUILD.bazel
+++ b/ruby/private/toolchains/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+package(default_visibility = ["//ruby/private:__pkg__"])
+
+# Placeholders for cases when no system ruby is requested
+string_flag(
+    name = "internal_missing_ruby",
+    build_setting_default = "none",
+    values = [
+        "none",
+        "ruby",
+        "jruby",
+    ],
+)
+
+config_setting(
+    name = "missing_jruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "jruby",
+    },
+)
+
+config_setting(
+    name = "missing_ruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "ruby",
+    },
+)
+
+config_setting(
+    name = "missing_no_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "none",
+    },
+)
+
+# vim: set ft=bzl :

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -3,6 +3,7 @@ load(
     "ruby_library",
     "ruby_toolchain",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -11,6 +12,10 @@ ruby_toolchain(
     interpreter = "//:ruby_bin",
     rules_ruby_workspace = "{rules_ruby_workspace}",
     runtime = "//:runtime",
+    headers = "//:headers",
+    target_settings = [
+        "{rules_ruby_workspace}//ruby/runtime:{setting}"
+    ],
     # TODO(yugui) Extract platform info from RbConfig
     # exec_compatible_with = [],
     # target_compatible_with = [],
@@ -44,6 +49,32 @@ filegroup(
             "WORKSPACE",
         ],
     ),
+)
+
+# Provide config settings to signal the ruby platform to downstream code.
+# This should never be overridden, and is determined automatically during the
+# creation of the toolchain.
+string_flag(
+    name = "internal_ruby_implementation",
+    build_setting_default = "{implementation}",
+    values = [
+        "ruby",
+        "jruby",
+    ],
+)
+
+config_setting(
+    name = "jruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "jruby",
+    },
+)
+
+config_setting(
+    name = "ruby_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "ruby",
+    },
 )
 
 # vim: set ft=bzl :

--- a/ruby/private/toolchains/BUILD.runtime.tpl
+++ b/ruby/private/toolchains/BUILD.runtime.tpl
@@ -1,55 +1,11 @@
-load(
-    "{rules_ruby_workspace}//ruby:defs.bzl",
-    "ruby_library",
-    "ruby_toolchain",
-)
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
-ruby_toolchain(
-    name = "toolchain",
-    interpreter = "//:ruby_bin",
-    rules_ruby_workspace = "{rules_ruby_workspace}",
-    runtime = "//:runtime",
-    headers = "//:headers",
-    target_settings = [
-        "{rules_ruby_workspace}//ruby/runtime:{setting}"
-    ],
-    # TODO(yugui) Extract platform info from RbConfig
-    # exec_compatible_with = [],
-    # target_compatible_with = [],
-)
-
-sh_binary(
-    name = "ruby_bin",
-    srcs = ["ruby"],
-    data = [":runtime"],
-)
-
-cc_import(
-    name = "libruby",
-    hdrs = glob({hdrs}),
-    shared_library = {shared_library},
-    static_library = {static_library},
-)
-
-cc_library(
-    name = "headers",
-    hdrs = glob({hdrs}),
-    includes = {includes},
-)
-
-filegroup(
-    name = "runtime",
-    srcs = glob(
-        include = ["**/*"],
-        exclude = [
-            "BUILD.bazel",
-            "WORKSPACE",
-        ],
-    ),
-)
+# Toolchain targets.  These will be mocked out with stubs if no ruby version
+# can be found.
+{toolchain}
 
 # Provide config settings to signal the ruby platform to downstream code.
 # This should never be overridden, and is determined automatically during the
@@ -58,6 +14,7 @@ string_flag(
     name = "internal_ruby_implementation",
     build_setting_default = "{implementation}",
     values = [
+        "none",
         "ruby",
         "jruby",
     ],
@@ -74,6 +31,13 @@ config_setting(
     name = "ruby_implementation",
     flag_values = {
         ":internal_ruby_implementation": "ruby",
+    },
+)
+
+config_setting(
+    name = "no_implementation",
+    flag_values = {
+        ":internal_ruby_implementation": "none",
     },
 )
 

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -1,6 +1,109 @@
 load("//ruby/private:constants.bzl", "RULES_RUBY_WORKSPACE_NAME")
 load("//ruby/private/toolchains:repository_context.bzl", "ruby_repository_context")
 
+_mock_toolchain = """
+load(
+    "{rules_ruby_workspace}//ruby:defs.bzl",
+    "ruby_mock_toolchain",
+)
+
+ruby_mock_toolchain(
+    name = "toolchain",
+    rules_ruby_workspace = "{rules_ruby_workspace}",
+)
+
+sh_binary(
+    name = "ruby_bin",
+    srcs = ["ruby"],
+    data = [":runtime"],
+)
+
+cc_import(
+    name = "libruby",
+    hdrs = [],
+)
+
+cc_library(
+    name = "headers",
+    hdrs = [],
+    includes = [],
+)
+
+filegroup(
+    name = "runtime",
+    srcs = [],
+)
+"""
+
+_toolchain = """
+load(
+    "{rules_ruby_workspace}//ruby:defs.bzl",
+    "ruby_toolchain",
+)
+
+ruby_toolchain(
+    name = "toolchain",
+    interpreter = "//:ruby_bin",
+    rules_ruby_workspace = "{rules_ruby_workspace}",
+    runtime = "//:runtime",
+    headers = "//:headers",
+    target_settings = [
+        "{rules_ruby_workspace}//ruby/runtime:{setting}"
+    ],
+    # TODO(yugui) Extract platform info from RbConfig
+    # exec_compatible_with = [],
+    # target_compatible_with = [],
+)
+
+sh_binary(
+    name = "ruby_bin",
+    srcs = ["ruby"],
+    data = [":runtime"],
+)
+
+cc_import(
+    name = "libruby",
+    hdrs = glob({hdrs}),
+    shared_library = {shared_library},
+    static_library = {static_library},
+)
+
+cc_library(
+    name = "headers",
+    hdrs = glob({hdrs}),
+    includes = {includes},
+)
+
+filegroup(
+    name = "runtime",
+    srcs = glob(
+        include = ["**/*"],
+        exclude = [
+            "BUILD.bazel",
+            "WORKSPACE",
+        ],
+    ),
+)
+"""
+
+_bundle_bzl = """
+load("{rules_ruby_workspace}//ruby/private/bundle:def.bzl", "ruby_bundle_impl")
+load("{rules_ruby_workspace}//ruby/private:constants.bzl", "BUNDLE_ATTRS")
+
+def _ruby_bundle_impl(ctx):
+    ruby_bundle_impl(ctx, "{interpreter}")
+
+ruby_bundle = repository_rule(
+    implementation = _ruby_bundle_impl,
+    attrs = BUNDLE_ATTRS,
+)
+"""
+
+_mock_bundle_bzl = """
+def ruby_bundle(**kwargs):
+    print("WARNING: no system ruby found for bundle")
+"""
+
 def _install_ruby_version(ctx, version):
     ctx.download_and_extract(
         url = "https://github.com/rbenv/ruby-build/archive/refs/tags/v20220825.tar.gz",
@@ -138,34 +241,47 @@ def _ruby_runtime_impl(ctx):
     else:
         _install_ruby_version(ctx, version)
         interpreter_path = ctx.path("./build/bin/ruby")
+        if not interpreter_path or not interpreter_path.exists:
+            fail("Installation of ruby version %s failed")
 
-    if not interpreter_path or not interpreter_path.exists:
-        fail(
-            "Command 'ruby' not found. Set $PATH or specify interpreter_path",
-            "interpreter_path",
+    if interpreter_path and interpreter_path.exists:
+        ruby = ruby_repository_context(ctx, interpreter_path)
+        installed = _install_ruby(ctx, ruby)
+        ruby_impl, ruby_version = get_ruby_info(ctx, interpreter_path)
+        hdrs = ["%s/**/*.h" % path for path in installed.includedirs]
+        toolchain = _toolchain.format(
+            includes = repr(installed.includedirs),
+            hdrs = repr(["%s/**/*.h" % path for path in installed.includedirs]),
+            static_library = repr(installed.static_library),
+            shared_library = repr(installed.shared_library),
+            rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
+            version = ruby_version,
+            setting = "config_system" if version == "system" else "config_%s-%s" % (ruby_impl, ruby_version),
         )
-
-    ruby = ruby_repository_context(ctx, interpreter_path)
-
-    installed = _install_ruby(ctx, ruby)
-
-    ruby_impl, ruby_version = get_ruby_info(ctx, interpreter_path)
+        bundle_bzl = _bundle_bzl.format(
+            interpreter = ruby.interpreter_realpath,
+            rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
+        )
+    else:
+        print("WARNING: no system ruby available, builds against system ruby will fail")
+        support = "none"
+        ruby_impl = "none"
+        toolchain = _mock_toolchain.format(
+            rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
+        )
+        ctx.file("ruby", content = "", executable = True)
+        bundle_bzl = _mock_bundle_bzl
 
     ctx.template(
         "BUILD.bazel",
         ctx.attr._buildfile_template,
         substitutions = {
-            "{includes}": repr(installed.includedirs),
-            "{hdrs}": repr(["%s/**/*.h" % path for path in installed.includedirs]),
-            "{static_library}": repr(installed.static_library),
-            "{shared_library}": repr(installed.shared_library),
-            "{rules_ruby_workspace}": RULES_RUBY_WORKSPACE_NAME,
+            "{toolchain}": toolchain,
             "{implementation}": ruby_impl,
-            "{version}": ruby_version,
-            "{setting}": "config_system" if version == "system" else "config_%s-%s" % (ruby_impl, ruby_version),
         },
         executable = False,
     )
+    ctx.file("bundle.bzl", bundle_bzl)
 
 ruby_runtime = repository_rule(
     implementation = _ruby_runtime_impl,

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -29,9 +29,14 @@ cc_library(
     includes = [],
 )
 
+java_binary(
+    name = "dummy_jar"
+    srcs = ["Dummy.java"],
+)
+
 filegroup(
     name = "jars",
-    srcs = [],
+    srcs = [":dummy_jar"],
 )
 
 filegroup(
@@ -80,9 +85,14 @@ cc_library(
     includes = {includes},
 )
 
+java_library(
+    name = "dummy_jar",
+    srcs = ["Dummy.java"],
+)
+
 filegroup(
     name = "jars",
-    srcs = glob({jars}),
+    srcs = {jars},
 )
 
 filegroup(
@@ -95,6 +105,13 @@ filegroup(
         ],
     ),
 )
+"""
+
+# Define a dummy java file for creating a no-op jar when JRuby isn't selected.
+_dummy_jar = """
+public class Dummy {
+    public static void main(String[] args) {}
+}
 """
 
 _bundle_bzl = """
@@ -255,6 +272,8 @@ def _ruby_runtime_impl(ctx):
         if not interpreter_path or not interpreter_path.exists:
             fail("Installation of ruby version %s failed")
 
+    ctx.file("Dummy.java", _dummy_jar)
+
     if interpreter_path and interpreter_path.exists:
         ruby = ruby_repository_context(ctx, interpreter_path)
         installed = _install_ruby(ctx, ruby)
@@ -263,7 +282,7 @@ def _ruby_runtime_impl(ctx):
         toolchain = _toolchain.format(
             includes = repr(installed.includedirs),
             hdrs = repr(["%s/**/*.h" % path for path in installed.includedirs]),
-            jars = repr(["**/lib/jruby.jar"] if ruby_impl == "jruby" else []),
+            jars = "glob([\"**/lib/jruby.jar\"])" if ruby_impl == "jruby" else [":dummy_jar"],
             static_library = repr(installed.static_library),
             shared_library = repr(installed.shared_library),
             rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -30,6 +30,11 @@ cc_library(
 )
 
 filegroup(
+    name = "jars",
+    srcs = [],
+)
+
+filegroup(
     name = "runtime",
     srcs = [],
 )
@@ -46,6 +51,7 @@ ruby_toolchain(
     interpreter = "//:ruby_bin",
     rules_ruby_workspace = "{rules_ruby_workspace}",
     runtime = "//:runtime",
+    jars = "//:jars",
     headers = "//:headers",
     target_settings = [
         "{rules_ruby_workspace}//ruby/runtime:{setting}"
@@ -72,6 +78,11 @@ cc_library(
     name = "headers",
     hdrs = glob({hdrs}),
     includes = {includes},
+)
+
+filegroup(
+    name = "jars",
+    srcs = glob({jars}),
 )
 
 filegroup(
@@ -252,6 +263,7 @@ def _ruby_runtime_impl(ctx):
         toolchain = _toolchain.format(
             includes = repr(installed.includedirs),
             hdrs = repr(["%s/**/*.h" % path for path in installed.includedirs]),
+            jars = repr(["**/lib/jruby.jar"] if ruby_impl == "jruby" else []),
             static_library = repr(installed.static_library),
             shared_library = repr(installed.shared_library),
             rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -76,7 +76,6 @@ selects.config_setting_group(
     selects.config_setting_group(
         name = "config_" + get_supported_version(version),
         match_any = [
-            ":config_auto",
             ":internal_config_" + get_supported_version(version),
         ],
     )

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -39,19 +39,46 @@ _ruby_interpreter_alias(
 # For example: --@rules_ruby//ruby/runtime:version=jruby-9.3
 string_flag(
     name = "version",
-    build_setting_default = "system",
-    values = ["system"] + SUPPORTED_MAJOR_MINOR_VERSIONS,
+    build_setting_default = "auto",
+    values = [
+        "auto",
+        "system",
+    ] + SUPPORTED_MAJOR_MINOR_VERSIONS,
 )
 
 config_setting(
-    name = "config_system",
+    name = "config_auto",
+    flag_values = {"version": "auto"},
+)
+
+config_setting(
+    name = "internal_config_system",
     flag_values = {"version": "system"},
 )
 
 [
     config_setting(
-        name = "config_" + get_supported_version(version),
+        name = "internal_config_" + get_supported_version(version),
         flag_values = {"version": version},
+    )
+    for version in SUPPORTED_MAJOR_MINOR_VERSIONS
+]
+
+selects.config_setting_group(
+    name = "config_system",
+    match_any = [
+        ":config_auto",
+        ":internal_config_system",
+    ],
+)
+
+[
+    selects.config_setting_group(
+        name = "config_" + get_supported_version(version),
+        match_any = [
+            ":config_auto",
+            ":internal_config_" + get_supported_version(version),
+        ],
     )
     for version in SUPPORTED_MAJOR_MINOR_VERSIONS
 ]
@@ -68,7 +95,7 @@ selects.config_setting_group(
     name = "config_system_ruby",
     match_all = [
         ":config_system",
-        "//external:rules_ruby_system_jruby_implementation",
+        "//external:rules_ruby_system_ruby_implementation",
     ],
 )
 
@@ -88,6 +115,14 @@ selects.config_setting_group(
 
 selects.config_setting_group(
     name = "config_jruby",
-    match_any = [":config_system_ruby"] +
+    match_any = [":config_system_jruby"] +
                 [":config_%s" % v for v in ALL_JRUBY_MAJOR_MINOR_VERSIONS],
+)
+
+selects.config_setting_group(
+    name = "config_system_none",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_no_implementation",
+    ],
 )

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -1,0 +1,93 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_ruby//ruby/private:constants.bzl", "get_supported_version")
+load(
+    ":version_support.bzl",
+    "ALL_JRUBY_MAJOR_MINOR_VERSIONS",
+    "ALL_RUBY_MAJOR_MINOR_VERSIONS",
+    "SUPPORTED_MAJOR_MINOR_VERSIONS",
+)
+load(
+    "@rules_ruby//ruby/private:runtime_alias.bzl",
+    _ruby_headers_alias = "ruby_headers_alias",
+    _ruby_interpreter_alias = "ruby_interpreter_alias",
+    _ruby_runtime_alias = "ruby_runtime_alias",
+)
+
+package(default_visibility = ["//visibility:public"])
+
+toolchain_type(name = "toolchain_type")
+
+# Alias targets corresponding to whichever toolchain was resolved based on
+# the selected version.
+
+_ruby_runtime_alias(
+    name = "runtime",
+)
+
+_ruby_headers_alias(
+    name = "headers",
+    runtime = ":runtime",
+)
+
+_ruby_interpreter_alias(
+    name = "interpreter",
+    runtime = ":runtime",
+)
+
+# Supported ruby versions, which can be selected by flags.
+# For example: --@rules_ruby//ruby/runtime:version=jruby-9.3
+string_flag(
+    name = "version",
+    build_setting_default = "system",
+    values = ["system"] + SUPPORTED_MAJOR_MINOR_VERSIONS,
+)
+
+config_setting(
+    name = "config_system",
+    flag_values = {"version": "system"},
+)
+
+[
+    config_setting(
+        name = "config_" + get_supported_version(version),
+        flag_values = {"version": version},
+    )
+    for version in SUPPORTED_MAJOR_MINOR_VERSIONS
+]
+
+[
+    alias(
+        name = "config_" + version,
+        actual = ":config_" + get_supported_version(version),
+    )
+    for version in SUPPORTED_MAJOR_MINOR_VERSIONS
+]
+
+selects.config_setting_group(
+    name = "config_system_ruby",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_jruby_implementation",
+    ],
+)
+
+selects.config_setting_group(
+    name = "config_ruby",
+    match_any = [":config_system_ruby"] +
+                [":config_%s" % v for v in ALL_RUBY_MAJOR_MINOR_VERSIONS],
+)
+
+selects.config_setting_group(
+    name = "config_system_jruby",
+    match_all = [
+        ":config_system",
+        "//external:rules_ruby_system_jruby_implementation",
+    ],
+)
+
+selects.config_setting_group(
+    name = "config_jruby",
+    match_any = [":config_system_ruby"] +
+                [":config_%s" % v for v in ALL_JRUBY_MAJOR_MINOR_VERSIONS],
+)

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 load(
     "@rules_ruby//ruby/private:runtime_alias.bzl",
     _ruby_headers_alias = "ruby_headers_alias",
+    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_interpreter_alias = "ruby_interpreter_alias",
     _ruby_runtime_alias = "ruby_runtime_alias",
 )
@@ -23,6 +24,11 @@ toolchain_type(name = "toolchain_type")
 
 _ruby_runtime_alias(
     name = "runtime",
+)
+
+_ruby_jars_alias(
+    name = "jars",
+    runtime = ":runtime",
 )
 
 _ruby_headers_alias(

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -10,8 +10,8 @@ load(
 load(
     "@rules_ruby//ruby/private:runtime_alias.bzl",
     _ruby_headers_alias = "ruby_headers_alias",
-    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_interpreter_alias = "ruby_interpreter_alias",
+    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_runtime_alias = "ruby_runtime_alias",
 )
 

--- a/ruby/runtime/version_support.bzl
+++ b/ruby/runtime/version_support.bzl
@@ -1,0 +1,26 @@
+load("@bazel_skylib//lib:new_sets.bzl", "sets")
+load(
+    "@rules_ruby//ruby/private:constants.bzl",
+    "SUPPORTED_VERSIONS",
+)
+
+def _major_minor_versions():
+    """Filters supported versions to unique major/minor pairs"""
+    versions = sets.make()
+    for s in SUPPORTED_VERSIONS:
+        if s.find(".") < 0:
+            continue
+        split = s.find(".", s.find(".") + 1)
+        sets.insert(versions, s[0:split])
+    return sorted(sets.to_list(versions))
+
+def _filter(versions, prefix):
+    filtered = []
+    for v in versions:
+        if v.startswith(prefix):
+            filtered.append(v)
+    return filtered
+
+SUPPORTED_MAJOR_MINOR_VERSIONS = _major_minor_versions()
+ALL_RUBY_MAJOR_MINOR_VERSIONS = _filter(SUPPORTED_MAJOR_MINOR_VERSIONS, "ruby-")
+ALL_JRUBY_MAJOR_MINOR_VERSIONS = _filter(SUPPORTED_MAJOR_MINOR_VERSIONS, "jruby-")

--- a/ruby/tests/BUILD.bazel
+++ b/ruby/tests/BUILD.bazel
@@ -65,7 +65,7 @@ sh_test(
     ],
     data = [
         "args_check.rb",
-        "@org_ruby_lang_ruby_toolchain//:ruby_bin",
+        "@rules_ruby//ruby/runtime:interpreter",
     ],
 )
 
@@ -74,7 +74,7 @@ genrule(
     name = "generate_genrule_run_ruby_test",
     outs = ["genrules_run_ruby_test.sh"],
     cmd = " && ".join([
-        ("$(location @org_ruby_lang_ruby_toolchain//:ruby_bin) " +
+        ("$(location @rules_ruby//ruby/runtime:interpreter) " +
          "$(location args_check.rb) foo bar baz"),
         "echo '#!/bin/sh -e' > $@",
         "echo true >> $@",
@@ -83,8 +83,8 @@ genrule(
     output_to_bindir = 1,
     tools = [
         "args_check.rb",
-        "@org_ruby_lang_ruby_toolchain//:ruby_bin",
-        "@org_ruby_lang_ruby_toolchain//:runtime",
+        "@rules_ruby//ruby/runtime",
+        "@rules_ruby//ruby/runtime:interpreter",
     ],
 )
 
@@ -188,7 +188,7 @@ cc_binary(
     testonly = True,
     srcs = ["example_ext.c"],
     linkshared = True,
-    deps = ["@org_ruby_lang_ruby_toolchain//:headers"],
+    deps = ["@rules_ruby//ruby/runtime:headers"],
 )
 
 cc_library(
@@ -197,7 +197,7 @@ cc_library(
     srcs = ["example_ext.c"],
     linkstatic = True,
     tags = ["manual"],
-    deps = ["@org_ruby_lang_ruby_toolchain//:headers"],
+    deps = ["@rules_ruby//ruby/runtime:headers"],
     alwayslink = True,
 )
 

--- a/ruby/tests/runtime_run_ruby_test.sh
+++ b/ruby/tests/runtime_run_ruby_test.sh
@@ -1,2 +1,2 @@
 #!/bin/sh -e
-external/org_ruby_lang_ruby_toolchain/ruby_bin $*
+ruby/runtime/ruby_interpreter $*

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,5 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:defs.bzl", "rules_ruby_select_sdk")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
 
-rules_ruby_select_sdk()
+rules_ruby_register_toolchains()

--- a/ruby/tests/testdata/another_workspace/WORKSPACE
+++ b/ruby/tests/testdata/another_workspace/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "rules_ruby_ruby_tests_testdata_another_workspace")
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-rules_ruby_register_toolchains()
+ruby_runtime("system_ruby")
+
+register_toolchains("@system_ruby//:toolchain")

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,15 +5,11 @@ local_repository(
     path = "../../../..",
 )
 
-load(
-    "@rules_ruby//ruby:deps.bzl",
-    "rules_ruby_dependencies",
-    "rules_ruby_select_sdk",
-)
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
 
 rules_ruby_dependencies()
 
-rules_ruby_select_sdk(version = "3.0.2")
+rules_ruby_register_toolchains(["ruby-3.0"])
 
 load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
 

--- a/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
+++ b/ruby/tests/testdata/bundle_includes_workspace/WORKSPACE
@@ -5,13 +5,17 @@ local_repository(
     path = "../../../..",
 )
 
-load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies", "rules_ruby_register_toolchains")
+load("@rules_ruby//ruby:deps.bzl", "rules_ruby_dependencies")
 
 rules_ruby_dependencies()
 
-rules_ruby_register_toolchains(["ruby-3.0"])
+load("@rules_ruby//ruby:defs.bzl", "ruby_runtime")
 
-load("@rules_ruby//ruby:defs.bzl", "ruby_bundle")
+ruby_runtime("ruby-3.0")
+
+register_toolchains("@ruby-3.0//:toolchain")
+
+load("@ruby-3.0//:bundle.bzl", "ruby_bundle")
 
 ruby_bundle(
     name = "gems",


### PR DESCRIPTION
This will allow downstream users to reference the JRuby jar corresponding to the version selected by rules_ruby, instead of pinning it with maven rules