### PR TITLE
Export JRuby jar files

### DIFF
--- a/ruby/private/providers.bzl
+++ b/ruby/private/providers.bzl
@@ -25,6 +25,7 @@ RubyRuntimeToolchainInfo = provider(
         "interpreter": "A label which points the Ruby interpreter",
         "bundler": "A label which points bundler command",
         "runtime": "A list of labels which points runtime libraries",
+        "jars": "A list of labels which points to ruby jars",
         "headers": "A list of labels which points to the ruby headers",
         "rubyopt": "A list of strings which should be passed to the interpreter as command line options",
     },

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -19,6 +19,30 @@ ruby_runtime_alias = rule(
     toolchains = [TOOLCHAIN_TYPE_NAME],
 )
 
+def _ruby_jars_alias_impl(ctx):
+    runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
+    target = runtime.jars
+    infos = [
+        DefaultInfo(
+            files = target.files,
+            runfiles = ctx.runfiles(transitive_files = target.files),
+        )
+    ]
+    for jar in infos[0].files.to_list():
+        infos.append(JavaInfo(jar, jar))
+    #fail(infos)
+    return infos
+
+ruby_jars_alias = rule(
+    implementation = _ruby_jars_alias_impl,
+    attrs = {
+        "runtime": attr.label(
+            doc = "The runtime alias to use.",
+            mandatory = True,
+        ),
+    },
+)
+
 def _ruby_headers_alias_impl(ctx):
     runtime = ctx.attr.runtime[RubyRuntimeToolchainInfo]
     target = runtime.headers

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -26,10 +26,11 @@ def _ruby_jars_alias_impl(ctx):
         DefaultInfo(
             files = target.files,
             runfiles = ctx.runfiles(transitive_files = target.files),
-        )
+        ),
     ]
     for jar in infos[0].files.to_list():
         infos.append(JavaInfo(jar, jar))
+
     #fail(infos)
     return infos
 

--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -31,7 +31,6 @@ def _ruby_jars_alias_impl(ctx):
     for jar in infos[0].files.to_list():
         infos.append(JavaInfo(jar, jar))
 
-    #fail(infos)
     return infos
 
 ruby_jars_alias = rule(

--- a/ruby/private/toolchain.bzl
+++ b/ruby/private/toolchain.bzl
@@ -7,6 +7,7 @@ def _ruby_toolchain_impl(ctx):
             ruby_runtime = RubyRuntimeToolchainInfo(
                 interpreter = ctx.attr.interpreter,
                 runtime = ctx.files.runtime,
+                jars = ctx.attr.jars,
                 headers = ctx.attr.headers,
                 rubyopt = ctx.attr.rubyopt,
             ),
@@ -27,6 +28,11 @@ _ruby_toolchain = rule(
             allow_files = True,
             cfg = "target",
         ),
+        "jars": attr.label(
+            mandatory = True,
+            allow_files = True,
+            cfg = "target",
+        ),
         "headers": attr.label(
             mandatory = True,
             allow_files = True,
@@ -42,6 +48,7 @@ def ruby_toolchain(
         name,
         interpreter,
         runtime,
+        jars,
         headers,
         rubyopt = [],
         rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,
@@ -51,6 +58,7 @@ def ruby_toolchain(
         name = impl_name,
         interpreter = interpreter,
         runtime = runtime,
+        jars = jars,
         headers = headers,
         rubyopt = rubyopt,
     )

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -29,9 +29,14 @@ cc_library(
     includes = [],
 )
 
+java_binary(
+    name = "dummy_jar"
+    srcs = ["Dummy.java"],
+)
+
 filegroup(
     name = "jars",
-    srcs = [],
+    srcs = [":dummy_jar"],
 )
 
 filegroup(
@@ -80,9 +85,14 @@ cc_library(
     includes = {includes},
 )
 
+java_library(
+    name = "dummy_jar",
+    srcs = ["Dummy.java"],
+)
+
 filegroup(
     name = "jars",
-    srcs = glob({jars}),
+    srcs = {jars},
 )
 
 filegroup(
@@ -95,6 +105,13 @@ filegroup(
         ],
     ),
 )
+"""
+
+# Define a dummy java file for creating a no-op jar when JRuby isn't selected.
+_dummy_jar = """
+public class Dummy {
+    public static void main(String[] args) {}
+}
 """
 
 _bundle_bzl = """
@@ -255,6 +272,8 @@ def _ruby_runtime_impl(ctx):
         if not interpreter_path or not interpreter_path.exists:
             fail("Installation of ruby version %s failed")
 
+    ctx.file("Dummy.java", _dummy_jar)
+
     if interpreter_path and interpreter_path.exists:
         ruby = ruby_repository_context(ctx, interpreter_path)
         installed = _install_ruby(ctx, ruby)
@@ -263,7 +282,7 @@ def _ruby_runtime_impl(ctx):
         toolchain = _toolchain.format(
             includes = repr(installed.includedirs),
             hdrs = repr(["%s/**/*.h" % path for path in installed.includedirs]),
-            jars = repr(["**/lib/jruby.jar"] if ruby_impl == "jruby" else []),
+            jars = "glob([\"**/lib/jruby.jar\"])" if ruby_impl == "jruby" else [":dummy_jar"],
             static_library = repr(installed.static_library),
             shared_library = repr(installed.shared_library),
             rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,

--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -30,6 +30,11 @@ cc_library(
 )
 
 filegroup(
+    name = "jars",
+    srcs = [],
+)
+
+filegroup(
     name = "runtime",
     srcs = [],
 )
@@ -46,6 +51,7 @@ ruby_toolchain(
     interpreter = "//:ruby_bin",
     rules_ruby_workspace = "{rules_ruby_workspace}",
     runtime = "//:runtime",
+    jars = "//:jars",
     headers = "//:headers",
     target_settings = [
         "{rules_ruby_workspace}//ruby/runtime:{setting}"
@@ -72,6 +78,11 @@ cc_library(
     name = "headers",
     hdrs = glob({hdrs}),
     includes = {includes},
+)
+
+filegroup(
+    name = "jars",
+    srcs = glob({jars}),
 )
 
 filegroup(
@@ -252,6 +263,7 @@ def _ruby_runtime_impl(ctx):
         toolchain = _toolchain.format(
             includes = repr(installed.includedirs),
             hdrs = repr(["%s/**/*.h" % path for path in installed.includedirs]),
+            jars = repr(["**/lib/jruby.jar"] if ruby_impl == "jruby" else []),
             static_library = repr(installed.static_library),
             shared_library = repr(installed.shared_library),
             rules_ruby_workspace = RULES_RUBY_WORKSPACE_NAME,

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -10,6 +10,7 @@ load(
 load(
     "@rules_ruby//ruby/private:runtime_alias.bzl",
     _ruby_headers_alias = "ruby_headers_alias",
+    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_interpreter_alias = "ruby_interpreter_alias",
     _ruby_runtime_alias = "ruby_runtime_alias",
 )
@@ -23,6 +24,11 @@ toolchain_type(name = "toolchain_type")
 
 _ruby_runtime_alias(
     name = "runtime",
+)
+
+_ruby_jars_alias(
+    name = "jars",
+    runtime = ":runtime",
 )
 
 _ruby_headers_alias(

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -10,8 +10,8 @@ load(
 load(
     "@rules_ruby//ruby/private:runtime_alias.bzl",
     _ruby_headers_alias = "ruby_headers_alias",
-    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_interpreter_alias = "ruby_interpreter_alias",
+    _ruby_jars_alias = "ruby_jars_alias",
     _ruby_runtime_alias = "ruby_runtime_alias",
 )
 


### PR DESCRIPTION
This will allow downstream users to reference the JRuby jar corresponding to the version selected by rules_ruby, instead of pinning it with maven rules