### PR TITLE
Add a jruby java_binary rule for deploy_env exclusion

### DIFF
--- a/ruby/private/runtime_alias.bzl
+++ b/ruby/private/runtime_alias.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_java//java:defs.bzl", "java_binary")
 load(":constants.bzl", "TOOLCHAIN_TYPE_NAME")
 load(":providers.bzl", "RubyRuntimeToolchainInfo")
 

--- a/ruby/runtime/BUILD.bazel
+++ b/ruby/runtime/BUILD.bazel
@@ -31,6 +31,12 @@ _ruby_jars_alias(
     runtime = ":runtime",
 )
 
+java_binary(
+    name = "jruby_binary",
+    main_class = "org.jruby.Main",
+    runtime_deps = [":jars"],
+)
+
 _ruby_headers_alias(
     name = "headers",
     runtime = ":runtime",


### PR DESCRIPTION
This will allow us to specify jruby in java_binary `deploy_env` arguments to remove it from our release artifacts