### PR TITLE
Set `allow_empty = True` on file globs

### DIFF
--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -74,14 +74,14 @@ sh_binary(
 
 cc_import(
     name = "libruby",
-    hdrs = glob({hdrs}),
+    hdrs = glob({hdrs}, allow_empty = True),
     shared_library = {shared_library},
     static_library = {static_library},
 )
 
 cc_library(
     name = "headers",
-    hdrs = glob({hdrs}),
+    hdrs = glob({hdrs}, allow_empty = True),
     includes = {includes},
 )
 


### PR DESCRIPTION
This allows everything to build successfully with the `--incompatible_disallow_empty_glob` flag, which will eventually be enabled by default. I believe these particular globs are expected to be empty if Ruby is not installed locally.