### PR TITLE
Make the ruby_runtime() rule re-load if PATH changes.

### DIFF
--- a/ruby/private/toolchains/ruby_runtime.bzl
+++ b/ruby/private/toolchains/ruby_runtime.bzl
@@ -331,4 +331,9 @@ ruby_runtime = repository_rule(
             allow_single_file = True,
         ),
     },
+    # Force a re-fetch when the Ruby version is changed through RVM.
+    # This will also force a re-download when PATH changes, which is
+    # unnecessary.  To fix this, we may want to make system_ruby()
+    # a different repository rule from ruby_runtime().
+    environ = ["PATH"],
 )


### PR DESCRIPTION
This will make `rvm use` commands take effect immediately, rather than requiring a `blaze clean --expunge` first.

This has an unfortunate side-effect of also forcing a re-download of hermetic Ruby versions when PATH changes. To fix this, we should make `system_ruby()` its own repository rule, so that hermetic Ruby versions are not affected by PATH.