### PR TITLE
Use `rubylibdir` and `ruby_version` from the Ruby Configuration

### DIFF
--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -198,15 +198,10 @@ class BundleBuildFileGenerator
     # what Ruby uses in the PATH to gems, eg. ruby 2.6.5 would have a folder called
     # ruby/2.6.0/gems for all minor versions of 2.6.*
     @ruby_version ||= begin
-        version_string = (RUBY_VERSION.split('.')[0..1] << 0).join('.')
-        if File.exist?("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{version_string}")
-            version_string
+        if File.exist?("{RbConfig::CONFIG['rubylibdir']}")
+            RbConfig::CONFIG['ruby_version']
         else
-            if File.exist?("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{version_string}+0")
-                version_string + "+0"
-            else
-                raise "Cannot find directory named #{version_string} within lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}"
-            end
+          raise "Cannot find directory named {RbConfig::CONFIG['rubylibdir']}"
         end
     end
   end

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -198,10 +198,10 @@ class BundleBuildFileGenerator
     # what Ruby uses in the PATH to gems, eg. ruby 2.6.5 would have a folder called
     # ruby/2.6.0/gems for all minor versions of 2.6.*
     @ruby_version ||= begin
-        if File.exist?("{RbConfig::CONFIG['rubylibdir']}")
+        if File.exist?(RbConfig::CONFIG['rubylibdir'])
             RbConfig::CONFIG['ruby_version']
         else
-          raise "Cannot find directory named {RbConfig::CONFIG['rubylibdir']}"
+          raise "Cannot find directory named #{RbConfig::CONFIG['rubylibdir']}"
         end
     end
   end


### PR DESCRIPTION
This is a more reliable way to get the version name matching the name of the ruby `lib` directory, as `rubylibdir` is defined as `"$(rubylibprefix)/$(ruby_version)"` and is also the location of the ruby `lib` directory.