### PR TITLE
Use `RUBY_BASE_NAME`, since that is what the libdir uses

### DIFF
--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -70,7 +70,7 @@ ALL_GEMS
 GEM_PATH = ->(ruby_version, gem_name, gem_version) do
   glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
   alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*").first
-  glob || alt_glob # || alt_alt_glob
+  glob || alt_glob
 end
 
 # For ordinary gems, this path is like 'lib/ruby/3.0.0/specifications/rspec-3.10.0.gemspec'.
@@ -85,7 +85,7 @@ end
 SPEC_PATH = ->(ruby_version, gem_name, gem_version) do
   glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
   alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*/**/*.gemspec").first
-  glob || alt_glob # || alt_alt_glob
+  glob || alt_glob
 end
 
 HERE = File.absolute_path '.'

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -70,7 +70,6 @@ ALL_GEMS
 GEM_PATH = ->(ruby_version, gem_name, gem_version) do
   glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
   alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*").first
-  # alt_alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/gems/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
   glob || alt_glob # || alt_alt_glob
 end
 
@@ -86,7 +85,6 @@ end
 SPEC_PATH = ->(ruby_version, gem_name, gem_version) do
   glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
   alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*/**/*.gemspec").first
-  # alt_alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/gems/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
   glob || alt_glob # || alt_alt_glob
 end
 

--- a/ruby/private/bundle/create_bundle_build_file.rb
+++ b/ruby/private/bundle/create_bundle_build_file.rb
@@ -68,9 +68,10 @@ ALL_GEMS
 #
 # Library path differs across implementations as `lib/ruby` on MRI and `lib/jruby` on JRuby.
 GEM_PATH = ->(ruby_version, gem_name, gem_version) do
-  glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
-  alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*").first
-  glob || alt_glob
+  glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
+  alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*").first
+  # alt_alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/gems/#{ruby_version}/gems/#{gem_name}-#{gem_version}*").first
+  glob || alt_glob # || alt_alt_glob
 end
 
 # For ordinary gems, this path is like 'lib/ruby/3.0.0/specifications/rspec-3.10.0.gemspec'.
@@ -83,9 +84,10 @@ end
 #
 # Library path differs across implementations as `lib/ruby` on MRI and `lib/jruby` on JRuby.
 SPEC_PATH = ->(ruby_version, gem_name, gem_version) do
-  glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
-  alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*/**/*.gemspec").first
-  glob || alt_glob
+  glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
+  alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{ruby_version}/bundler/gems/#{gem_name}-*/**/*.gemspec").first
+  # alt_alt_glob = Dir.glob("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/gems/#{ruby_version}/specifications/#{gem_name}-#{gem_version}*.gemspec").first
+  glob || alt_glob # || alt_alt_glob
 end
 
 HERE = File.absolute_path '.'
@@ -199,13 +201,13 @@ class BundleBuildFileGenerator
     # ruby/2.6.0/gems for all minor versions of 2.6.*
     @ruby_version ||= begin
         version_string = (RUBY_VERSION.split('.')[0..1] << 0).join('.')
-        if File.exist?("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{version_string}")
+        if File.exist?("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{version_string}")
             version_string
         else
-            if File.exist?("lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}/#{version_string}+0")
+            if File.exist?("lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}/#{version_string}+0")
                 version_string + "+0"
             else
-                raise "Cannot find directory named #{version_string} within lib/#{RbConfig::CONFIG['RUBY_INSTALL_NAME']}"
+                raise "Cannot find directory named #{version_string} within lib/#{RbConfig::CONFIG['RUBY_BASE_NAME']}"
             end
         end
     end


### PR DESCRIPTION
Documented here: https://idiosyncratic-ruby.com/42-ruby-config.html

Without this patch, I get:
```
create_bundle_build_file.rb:208:in `initialize': Cannot find directory named 3.1.0 within lib/ruby3.1 (RuntimeError)
        from create_bundle_build_file.rb:351:in `new'
        from create_bundle_build_file.rb:351:in `<main>'
INFO: Repository protobuf_bundle instantiated at:
  /home/zoey/src/software/protobuf/WORKSPACE:140:12: in <toplevel>
Repository rule ruby_bundle defined at:
  /home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/system_ruby/bundle.bzl:8:30: in <toplevel>
ERROR: An error occurred during the fetch of repository 'protobuf_bundle':
   Traceback (most recent call last):
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/system_ruby/bundle.bzl", line 6, column 21, in _ruby_bundle_impl
                ruby_bundle_impl(ctx, "/usr/bin/ruby3.1")
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/rules_ruby/ruby/private/bundle/def.bzl", line 220, column 31, in ruby_bundle_impl
                generate_bundle_build_file(runtime_ctx, result)
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/rules_ruby/ruby/private/bundle/def.bzl", line 174, column 13, in generate_bundle_build_file
                fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
Error in fail: build file generation failed: create_bundle_build_file.rb:208:in `initialize': Cannot find directory named 3.1.0 within lib/ruby3.1 (RuntimeError)
        from create_bundle_build_file.rb:351:in `new'
        from create_bundle_build_file.rb:351:in `<main>'
ERROR: no such package '@@protobuf_bundle//': build file generation failed: create_bundle_build_file.rb:208:in `initialize': Cannot find directory named 3.1.0 within lib/ruby3.1 (RuntimeError)
        from create_bundle_build_file.rb:351:in `new'
        from create_bundle_build_file.rb:351:in `<main>'
ERROR: /home/zoey/src/software/protobuf/ruby/lib/google/BUILD.bazel:63:13: //ruby/lib/google:protobuf_lib depends on @@protobuf_bundle//:bigdecimal in repository @@protobuf_bundle which failed to fetch. no such package '@@protobuf_bundle
//': build file generation failed: create_bundle_build_file.rb:208:in `initialize': Cannot find directory named 3.1.0 within lib/ruby3.1 (RuntimeError)
        from create_bundle_build_file.rb:351:in `new'
        from create_bundle_build_file.rb:351:in `<main>'
ERROR: Analysis of target '//ruby/lib/google:protobuf_lib' failed; build aborted: Analysis failed
INFO: Elapsed time: 16.822s, Critical Path: 0.02s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```

and if I only change enough to fix that specific error, I get:
```
/usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `initialize': no implicit conversion of nil into String (TypeError)
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open'
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open_file'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:114:in `data'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:173:in `extensions'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:331:in `have_extensions?'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:248:in `require_paths'
        from create_bundle_build_file.rb:277:in `register_gem'
        from create_bundle_build_file.rb:232:in `block in generate!'
        from create_bundle_build_file.rb:232:in `each'
        from create_bundle_build_file.rb:232:in `generate!'
        from create_bundle_build_file.rb:356:in `<main>'
INFO: Repository protobuf_bundle instantiated at:
  /home/zoey/src/software/protobuf/WORKSPACE:140:12: in <toplevel>
Repository rule ruby_bundle defined at:
  /home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/system_ruby/bundle.bzl:8:30: in <toplevel>
ERROR: An error occurred during the fetch of repository 'protobuf_bundle':
   Traceback (most recent call last):
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/system_ruby/bundle.bzl", line 6, column 21, in _ruby_bundle_impl
                ruby_bundle_impl(ctx, "/usr/bin/ruby3.1")
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/rules_ruby/ruby/private/bundle/def.bzl", line 220, column 31, in ruby_bundle_impl
                generate_bundle_build_file(runtime_ctx, result)
        File "/home/zoey/.cache/bazel/_bazel_zoey/48c075afba7cdea78ebdc9043475bc88/external/rules_ruby/ruby/private/bundle/def.bzl", line 174, column 13, in generate_bundle_build_file
                fail("build file generation failed: %s%s" % (result.stdout, result.stderr))
Error in fail: build file generation failed: /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `initialize': no implicit conversion of nil into String (TypeError)
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open'
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open_file'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:114:in `data'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:173:in `extensions'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:331:in `have_extensions?'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:248:in `require_paths'
        from create_bundle_build_file.rb:277:in `register_gem'
        from create_bundle_build_file.rb:232:in `block in generate!'
        from create_bundle_build_file.rb:232:in `each'
        from create_bundle_build_file.rb:232:in `generate!'
        from create_bundle_build_file.rb:356:in `<main>'
ERROR: no such package '@@protobuf_bundle//': build file generation failed: /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `initialize': no implicit conversion of nil into String (TypeError)
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open'
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open_file'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:114:in `data'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:173:in `extensions'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:331:in `have_extensions?'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:248:in `require_paths'
        from create_bundle_build_file.rb:277:in `register_gem'
        from create_bundle_build_file.rb:232:in `block in generate!'
        from create_bundle_build_file.rb:232:in `each'
        from create_bundle_build_file.rb:232:in `generate!'
        from create_bundle_build_file.rb:356:in `<main>'
ERROR: /home/zoey/src/software/protobuf/ruby/tests/BUILD.bazel:65:10: //ruby/tests:gc_test depends on @@protobuf_bundle//:test-unit in repository @@protobuf_bundle which failed to fetch. no such package '@@protobuf_bundle//': build file generation failed: /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `in
itialize': no implicit conversion of nil into String (TypeError)
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open'
        from /usr/lib/ruby/vendor_ruby/rubygems.rb:786:in `open_file'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:114:in `data'
        from /usr/lib/ruby/vendor_ruby/rubygems/stub_specification.rb:173:in `extensions'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:331:in `have_extensions?'
        from /usr/lib/ruby/vendor_ruby/rubygems/basic_specification.rb:248:in `require_paths'
        from create_bundle_build_file.rb:277:in `register_gem'
        from create_bundle_build_file.rb:232:in `block in generate!'
        from create_bundle_build_file.rb:232:in `each'
        from create_bundle_build_file.rb:232:in `generate!'
        from create_bundle_build_file.rb:356:in `<main>'
ERROR: Analysis of target '//ruby/tests:gc_test' failed; build aborted: Analysis failed
INFO: Elapsed time: 15.767s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
ERROR: Build did NOT complete successfully
```

when trying to build https://github.com/protocolbuffers/protobuf